### PR TITLE
Fixed typo in NRF52Serial::setBaudrate(). & Added newline at EOF.

### DIFF
--- a/source/NRF52Serial.cpp
+++ b/source/NRF52Serial.cpp
@@ -49,11 +49,11 @@ int NRF52Serial::setBaudrate(uint32_t baudrate)
 {
     nrf_uarte_baudrate_t baud = NRF_UARTE_BAUDRATE_115200;
 
-    if (baud == 1000000)
+    if (baudrate == 1000000)
         baud = NRF_UARTE_BAUDRATE_1000000;
-    else if (baud == 38400)
+    else if (baudrate == 38400)
         baud = NRF_UARTE_BAUDRATE_38400;
-    else if (baud == 9600)
+    else if (baudrate == 9600)
         baud = NRF_UARTE_BAUDRATE_9600;
 
     nrf_uarte_baudrate_set(this->uart_instance.p_reg, baud);


### PR DESCRIPTION
I fixed a misuse of local variables and parameter names in function NRF52Serial::setBaudrate(). 
This modification allows you to change the baudrate of the serial normally.

And, I [added a newline at the end of the file to ensure normal file comparisons between different systems](https://stackoverflow.com/questions/5813311/no-newline-at-end-of-file).