### PR TITLE
fixes for PWM, PDM and serial

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ list(APPEND SOURCE_FILES "nrfx/mdk/gcc_startup_${DEV}.S")
 list(APPEND SOURCE_FILES "nrfx/drivers/src/nrfx_uarte.c")
 list(APPEND SOURCE_FILES "nrfx/drivers/src/prs/nrfx_prs.c")
 
-
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DNRFX_PRS_ENABLED=0")
 
 # add them
 include_directories(${INCLUDE_DIRS})

--- a/inc/NRF52PWM.h
+++ b/inc/NRF52PWM.h
@@ -24,11 +24,13 @@ private:
     int             dataReady;
     int             sampleRate;
 
+    void prefill();
+
 public:
 
     // The stream component that is serving our data
     DataSource  &upstream;
-    ManagedBuffer output;
+    ManagedBuffer buffer, nextBuffer;
 
     /**
       * Constructor for an instance of a DAC.

--- a/inc/NRF52Serial.h
+++ b/inc/NRF52Serial.h
@@ -33,7 +33,7 @@ namespace codal
          * @param rx the pin instance to use for reception
          *
          **/
-        NRF52Serial(Pin& tx, Pin& rx, NRF_UARTE_Type* uart);
+        NRF52Serial(Pin& tx, Pin& rx, NRF_UARTE_Type* uart = NULL);
 
         int enable();
         int disable();

--- a/source/NRF52PDM.cpp
+++ b/source/NRF52PDM.cpp
@@ -102,8 +102,8 @@ NRF52PDM::NRF52PDM(Pin &sd, Pin &sck, uint16_t id) : output(*this)
     this->setGain(40);
 
 
-    // Configure buffer size.
-    NRF_PDM->SAMPLE.MAXCNT = NRF52_PDM_BUFFER_SIZE;
+    // Configure buffer size - samples are 2 bytes each
+    NRF_PDM->SAMPLE.MAXCNT = NRF52_PDM_BUFFER_SIZE / 2;
 
     // Record our sample rate for future computation.
     // This is a constant of the PDM samplerate / 64 (as defined in nrf52 specification, seciton 44).

--- a/source/NRF52Serial.cpp
+++ b/source/NRF52Serial.cpp
@@ -102,6 +102,12 @@ int NRF52Serial::getc()
 NRF52Serial::NRF52Serial(Pin& tx, Pin& rx, NRF_UARTE_Type* uart) : Serial(tx, rx)
 {
     memset(&this->uart_instance, 0, sizeof(nrfx_uarte_t));
+
+    if (uart == NULL)
+    {
+        uart = NRF_UARTE0;
+    }
+    
     this->uart_instance.p_reg = uart;
 
     nrfx_uarte_config_t uart_config;

--- a/source/codal_target_hal_base.cpp
+++ b/source/codal_target_hal_base.cpp
@@ -1,0 +1,148 @@
+#include "cmsis.h"
+#include "codal_target_hal.h"
+#include "CodalDmesg.h"
+#include "CodalCompat.h"
+#include "Timer.h"
+
+void target_enable_irq()
+{
+    __enable_irq();
+}
+
+void target_disable_irq()
+{
+    __disable_irq();
+}
+
+void target_wait_for_event()
+{
+    __WFE();
+}
+
+uint64_t target_get_serial()
+{
+    return ((uint64_t)NRF_FICR->DEVICEID[1] << 32) | NRF_FICR->DEVICEID[0];
+}
+
+void target_reset()
+{
+    NVIC_SystemReset();
+}
+
+
+extern "C" void _start();
+extern "C" __attribute__((weak)) void user_init() {}
+
+extern "C" void target_start()
+{
+    NRF_NVMC->ICACHECNF = NVMC_ICACHECNF_CACHEEN_Enabled;
+    user_init();
+    _start();
+}
+
+/**
+  *  Thread Context for an ARM Cortex core.
+  *
+  * This is probably overkill, but the ARMCC compiler uses a lot register optimisation
+  * in its calling conventions, so better safe than sorry!
+  */
+struct PROCESSOR_TCB
+{
+    uint32_t R0;
+    uint32_t R1;
+    uint32_t R2;
+    uint32_t R3;
+    uint32_t R4;
+    uint32_t R5;
+    uint32_t R6;
+    uint32_t R7;
+    uint32_t R8;
+    uint32_t R9;
+    uint32_t R10;
+    uint32_t R11;
+    uint32_t R12;
+    uint32_t SP;
+    uint32_t LR;
+    uint32_t stack_base;
+};
+
+PROCESSOR_WORD_TYPE fiber_initial_stack_base()
+{
+    uint32_t mbed_stack_base;
+
+#ifdef MBED_CONF_RTOS_PRESENT
+    extern osThreadAttr_t _main_thread_attr;
+    mbed_stack_base = (uint32_t)_main_thread_attr.stack_mem + _main_thread_attr.stack_size;
+#else
+    mbed_stack_base = DEVICE_STACK_BASE;
+#endif
+
+    return mbed_stack_base;
+}
+
+void* tcb_allocate()
+{
+    return (void *)malloc(sizeof(PROCESSOR_TCB));
+}
+
+/**
+  * Configures the link register of the given tcb to have the value function.
+  *
+  * @param tcb The tcb to modify
+  * @param function the function the link register should point to.
+  */
+void tcb_configure_lr(void* tcb, PROCESSOR_WORD_TYPE function)
+{
+    PROCESSOR_TCB* tcbPointer = (PROCESSOR_TCB *)tcb;
+    tcbPointer->LR = function;
+}
+
+/**
+  * Configures the link register of the given tcb to have the value function.
+  *
+  * @param tcb The tcb to modify
+  * @param function the function the link register should point to.
+  */
+void tcb_configure_sp(void* tcb, PROCESSOR_WORD_TYPE sp)
+{
+    PROCESSOR_TCB* tcbPointer = (PROCESSOR_TCB *)tcb;
+    tcbPointer->SP = sp;
+}
+
+void tcb_configure_stack_base(void* tcb, PROCESSOR_WORD_TYPE stack_base)
+{
+    PROCESSOR_TCB* tcbPointer = (PROCESSOR_TCB *)tcb;
+    tcbPointer->stack_base = stack_base;
+}
+
+PROCESSOR_WORD_TYPE tcb_get_stack_base(void* tcb)
+{
+    PROCESSOR_TCB* tcbPointer = (PROCESSOR_TCB *)tcb;
+    return tcbPointer->stack_base;
+}
+
+PROCESSOR_WORD_TYPE get_current_sp()
+{
+#ifdef MBED_CONF_RTOS_PRESENT
+    return __get_PSP();
+#else
+    return __get_MSP();
+#endif
+}
+
+PROCESSOR_WORD_TYPE tcb_get_sp(void* tcb)
+{
+    PROCESSOR_TCB* tcbPointer = (PROCESSOR_TCB *)tcb;
+    return tcbPointer->SP;
+}
+
+void tcb_configure_args(void* tcb, PROCESSOR_WORD_TYPE ep, PROCESSOR_WORD_TYPE cp, PROCESSOR_WORD_TYPE pm)
+{
+    PROCESSOR_TCB* tcbPointer = (PROCESSOR_TCB *)tcb;
+    tcbPointer->R0 = (uint32_t) ep;
+    tcbPointer->R1 = (uint32_t) cp;
+    tcbPointer->R2 = (uint32_t) pm;
+}
+
+extern PROCESSOR_WORD_TYPE __end__;
+PROCESSOR_WORD_TYPE codal_heap_start = (PROCESSOR_WORD_TYPE)(&__end__);

--- a/source/codal_target_hal_base.cpp
+++ b/source/codal_target_hal_base.cpp
@@ -68,16 +68,7 @@ struct PROCESSOR_TCB
 
 PROCESSOR_WORD_TYPE fiber_initial_stack_base()
 {
-    uint32_t mbed_stack_base;
-
-#ifdef MBED_CONF_RTOS_PRESENT
-    extern osThreadAttr_t _main_thread_attr;
-    mbed_stack_base = (uint32_t)_main_thread_attr.stack_mem + _main_thread_attr.stack_size;
-#else
-    mbed_stack_base = DEVICE_STACK_BASE;
-#endif
-
-    return mbed_stack_base;
+    return DEVICE_STACK_BASE;
 }
 
 void* tcb_allocate()
@@ -123,11 +114,7 @@ PROCESSOR_WORD_TYPE tcb_get_stack_base(void* tcb)
 
 PROCESSOR_WORD_TYPE get_current_sp()
 {
-#ifdef MBED_CONF_RTOS_PRESENT
-    return __get_PSP();
-#else
     return __get_MSP();
-#endif
 }
 
 PROCESSOR_WORD_TYPE tcb_get_sp(void* tcb)

--- a/source/codal_target_hal_base.cpp
+++ b/source/codal_target_hal_base.cpp
@@ -32,10 +32,21 @@ void target_reset()
 extern "C" void _start();
 extern "C" __attribute__((weak)) void user_init() {}
 
+#define NUM_VTOR_ENTRIES (NVIC_USER_IRQ_OFFSET + 48)
+
+__attribute__((aligned(256)))
+static uint32_t vtorStorage[NUM_VTOR_ENTRIES];
+static void relocate_vtor()
+{
+    memcpy(vtorStorage, (void *)SCB->VTOR, sizeof(vtorStorage));
+    SCB->VTOR = (uint32_t)vtorStorage;
+}
+
 extern "C" void target_start()
 {
     NRF_NVMC->ICACHECNF = NVMC_ICACHECNF_CACHEEN_Enabled;
     user_init();
+    relocate_vtor();
     _start();
 }
 

--- a/source/codal_target_hal_base.cpp
+++ b/source/codal_target_hal_base.cpp
@@ -29,7 +29,6 @@ void target_reset()
     NVIC_SystemReset();
 }
 
-
 extern "C" void _start();
 extern "C" __attribute__((weak)) void user_init() {}
 
@@ -41,11 +40,11 @@ extern "C" void target_start()
 }
 
 /**
-  *  Thread Context for an ARM Cortex core.
-  *
-  * This is probably overkill, but the ARMCC compiler uses a lot register optimisation
-  * in its calling conventions, so better safe than sorry!
-  */
+ *  Thread Context for an ARM Cortex core.
+ *
+ * This is probably overkill, but the ARMCC compiler uses a lot register optimisation
+ * in its calling conventions, so better safe than sorry!
+ */
 struct PROCESSOR_TCB
 {
     uint32_t R0;
@@ -71,44 +70,44 @@ PROCESSOR_WORD_TYPE fiber_initial_stack_base()
     return DEVICE_STACK_BASE;
 }
 
-void* tcb_allocate()
+void *tcb_allocate()
 {
     return (void *)malloc(sizeof(PROCESSOR_TCB));
 }
 
 /**
-  * Configures the link register of the given tcb to have the value function.
-  *
-  * @param tcb The tcb to modify
-  * @param function the function the link register should point to.
-  */
-void tcb_configure_lr(void* tcb, PROCESSOR_WORD_TYPE function)
+ * Configures the link register of the given tcb to have the value function.
+ *
+ * @param tcb The tcb to modify
+ * @param function the function the link register should point to.
+ */
+void tcb_configure_lr(void *tcb, PROCESSOR_WORD_TYPE function)
 {
-    PROCESSOR_TCB* tcbPointer = (PROCESSOR_TCB *)tcb;
+    PROCESSOR_TCB *tcbPointer = (PROCESSOR_TCB *)tcb;
     tcbPointer->LR = function;
 }
 
 /**
-  * Configures the link register of the given tcb to have the value function.
-  *
-  * @param tcb The tcb to modify
-  * @param function the function the link register should point to.
-  */
-void tcb_configure_sp(void* tcb, PROCESSOR_WORD_TYPE sp)
+ * Configures the link register of the given tcb to have the value function.
+ *
+ * @param tcb The tcb to modify
+ * @param function the function the link register should point to.
+ */
+void tcb_configure_sp(void *tcb, PROCESSOR_WORD_TYPE sp)
 {
-    PROCESSOR_TCB* tcbPointer = (PROCESSOR_TCB *)tcb;
+    PROCESSOR_TCB *tcbPointer = (PROCESSOR_TCB *)tcb;
     tcbPointer->SP = sp;
 }
 
-void tcb_configure_stack_base(void* tcb, PROCESSOR_WORD_TYPE stack_base)
+void tcb_configure_stack_base(void *tcb, PROCESSOR_WORD_TYPE stack_base)
 {
-    PROCESSOR_TCB* tcbPointer = (PROCESSOR_TCB *)tcb;
+    PROCESSOR_TCB *tcbPointer = (PROCESSOR_TCB *)tcb;
     tcbPointer->stack_base = stack_base;
 }
 
-PROCESSOR_WORD_TYPE tcb_get_stack_base(void* tcb)
+PROCESSOR_WORD_TYPE tcb_get_stack_base(void *tcb)
 {
-    PROCESSOR_TCB* tcbPointer = (PROCESSOR_TCB *)tcb;
+    PROCESSOR_TCB *tcbPointer = (PROCESSOR_TCB *)tcb;
     return tcbPointer->stack_base;
 }
 
@@ -117,18 +116,19 @@ PROCESSOR_WORD_TYPE get_current_sp()
     return __get_MSP();
 }
 
-PROCESSOR_WORD_TYPE tcb_get_sp(void* tcb)
+PROCESSOR_WORD_TYPE tcb_get_sp(void *tcb)
 {
-    PROCESSOR_TCB* tcbPointer = (PROCESSOR_TCB *)tcb;
+    PROCESSOR_TCB *tcbPointer = (PROCESSOR_TCB *)tcb;
     return tcbPointer->SP;
 }
 
-void tcb_configure_args(void* tcb, PROCESSOR_WORD_TYPE ep, PROCESSOR_WORD_TYPE cp, PROCESSOR_WORD_TYPE pm)
+void tcb_configure_args(void *tcb, PROCESSOR_WORD_TYPE ep, PROCESSOR_WORD_TYPE cp,
+                        PROCESSOR_WORD_TYPE pm)
 {
-    PROCESSOR_TCB* tcbPointer = (PROCESSOR_TCB *)tcb;
-    tcbPointer->R0 = (uint32_t) ep;
-    tcbPointer->R1 = (uint32_t) cp;
-    tcbPointer->R2 = (uint32_t) pm;
+    PROCESSOR_TCB *tcbPointer = (PROCESSOR_TCB *)tcb;
+    tcbPointer->R0 = (uint32_t)ep;
+    tcbPointer->R1 = (uint32_t)cp;
+    tcbPointer->R2 = (uint32_t)pm;
 }
 
 extern PROCESSOR_WORD_TYPE __end__;


### PR DESCRIPTION
Enables most of CP-Blue in Maker.

* move codal target hal to codal-nrf52 - only really target specific stuff should go in target repo (there is several of them)
* copy VTOR to RAM (for NVIC_SetVector)
* add simple double-buffer in PWM (MakeCode synthesizer needs it)
* fix buffer overrun in PWM
* remove PRS (which is some Nordic peripheral allocation thingy - conflicts with I2C/SPI)
