### PR TITLE
Fix incorrect mapping for BitMode32

### DIFF
--- a/source/NRFLowLevelTimer.cpp
+++ b/source/NRFLowLevelTimer.cpp
@@ -229,7 +229,7 @@ int NRFLowLevelTimer::setBitMode(TimerBitMode t)
             timer->BITMODE = 2;
             break;
         case BitMode32:
-            timer->BITMODE = 2;
+            timer->BITMODE = 3;
             break;
     }
 


### PR DESCRIPTION
Fixes #22.

I've checked NRF52832, NRF52833, NRF52840 datasheets, and this change should correctly apply to all of them. A quick verification would be nice @bsiever?

Thanks for the heads up :smile: 