### PR TITLE
Alternative NRF52ADC support for NRF52Pin::getAnalogue

### DIFF
--- a/inc/NRF52ADC.h
+++ b/inc/NRF52ADC.h
@@ -31,6 +31,12 @@ DEALINGS IN THE SOFTWARE.
 #ifndef NRF5_ADC_H
 #define NRF5_ADC_H
 
+#define NRF52ADC_RECENT_SAMPLE 1
+
+#if NRF52ADC_RECENT_SAMPLE
+class NRF52ADC;
+#endif
+
 //
 // Constants
 //
@@ -171,6 +177,16 @@ public:
      * @return 1 if this channel changes status, ero otherwise.
      */
     int servicePendingRequests();
+
+#if NRF52ADC_RECENT_SAMPLE
+    volatile int16_t recentSample;
+
+    uint16_t getRecentSample( NRF52ADC *adc);
+
+    bool demuxRecentSample( ManagedBuffer dmaBuffer, int offset, int skip, int samplesInBuffer);
+
+    void waitForSample();
+#endif
 };
 
 #define NRF52ADC_STATUS_PERIOD_CHANGED              0x01        // Indicates that the period of the ADC may have changed.
@@ -255,6 +271,13 @@ public:
      */
     int releaseChannel(Pin& pin);
 
+#if NRF52ADC_RECENT_SAMPLE
+    NRF52ADCChannel* getEnabledChannel(Pin& pin);
+
+    void fillDMABuffer( ManagedBuffer &b);
+    
+    void updateRecentSample();
+#endif
 };
 
 #endif

--- a/source/NRF52Pin.cpp
+++ b/source/NRF52Pin.cpp
@@ -427,10 +427,17 @@ int NRF52Pin::getAnalogValue()
 
     if (adc)
     {
+#if NRF52ADC_RECENT_SAMPLE
+        NRF52ADCChannel *c = adc->getEnabledChannel(*this);
+
+        if (c)
+            return c->getRecentSample( adc) / 16;
+#else
         NRF52ADCChannel *c = adc->getChannel(*this);
 
         if (c)
             return c->getSample() / 16;
+#endif
     }
 
     return DEVICE_NOT_SUPPORTED;


### PR DESCRIPTION
To fix https://github.com/lancaster-university/codal-microbit-v2/issues/81
As suggested by @finneyj, avoids stopping the continuous ADC.
Enabled by #define NRF52ADC_RECENT_SAMPLE 1 in NRF52ADC.h

WORK IN PROGRESS... I have added extra functions, which perhaps should be replacements for existing ones. 