### PR TITLE
Add case for 31250 in switch(baudrate)

### DIFF
--- a/source/NRF52Serial.cpp
+++ b/source/NRF52Serial.cpp
@@ -196,6 +196,7 @@ int NRF52Serial::setBaudrate(uint32_t baudrate)
     switch(baudrate)
     {
         case 9600 : baud = NRF_UARTE_BAUDRATE_9600; break;
+        case 31250 : baud = NRF_UARTE_BAUDRATE_31250; break;
         case 38400 : baud = NRF_UARTE_BAUDRATE_38400; break;
         case 57600 : baud = NRF_UARTE_BAUDRATE_57600; break;
         case 115200 : baud = NRF_UARTE_BAUDRATE_115200; break;


### PR DESCRIPTION
see issue #38 
micro:bit V2 can currently not send MIDI to other hardware because the baudrate cannot be set to 31250, despite this setting being available via the block editor as an enum. 

the sdk for the nrf52 includes support for 31250 baud but it has simply been omitted here.