### PR TITLE
Avoid occasional hang in NRF52I2C::waitForStop

### DIFF
--- a/inc/NRF52I2C.h
+++ b/inc/NRF52I2C.h
@@ -40,6 +40,9 @@ class NRF52I2C : public codal::I2C
     int minimumBusIdlePeriod;
 
     int waitForStop(int evt);
+
+    void checkError();
+
 protected:
     NRF52Pin &sda, &scl;
     NRF_TWIM_Type *p_twim;

--- a/inc/NRF52I2C.h
+++ b/inc/NRF52I2C.h
@@ -40,9 +40,6 @@ class NRF52I2C : public codal::I2C
     int minimumBusIdlePeriod;
 
     int waitForStop(int evt);
-
-    void checkError();
-
 protected:
     NRF52Pin &sda, &scl;
     NRF_TWIM_Type *p_twim;

--- a/source/NRF52I2C.cpp
+++ b/source/NRF52I2C.cpp
@@ -149,6 +149,7 @@ int NRF52I2C::waitForStop(int evt)
 
             if ( !stopped)
             {
+                // Occasionally RESUME then STOP doesn't trigger STOPPED 
                 // Disable, repeat constructor initialisation, enable.
                 // Takes about 30 microseconds
                 nrf_twim_disable(p_twim);

--- a/source/NRF52I2C.cpp
+++ b/source/NRF52I2C.cpp
@@ -137,12 +137,13 @@ int NRF52I2C::waitForStop(int evt)
 
             bool stopped = false;
 
-            for ( int i = 0; i < 100; i++)
+            for ( int i = 0; i < 1000000; i++)
             {
                 target_wait_us(10);
                 if (nrf_twim_event_check(p_twim, NRF_TWIM_EVENT_STOPPED))
                 {
                     stopped = true;
+                    DMESG( "NRF52I2C STOPPED %d", i);
                     break;
                 }
             }
@@ -170,6 +171,7 @@ int NRF52I2C::waitForStop(int evt)
                 nrf_twim_pins_set(p_twim, scl.name, sda.name);
                 nrf_twim_frequency_set(p_twim, NRF_TWIM_FREQ_100K);
                 nrf_twim_enable(p_twim);
+                DMESG( "NRF52I2C RECOVERED");
             }
             break;
         }

--- a/source/NRF52I2C.cpp
+++ b/source/NRF52I2C.cpp
@@ -106,6 +106,26 @@ int NRF52I2C::setFrequency(uint32_t frequency)
     return DEVICE_OK;
 }
 
+void NRF52I2C::checkError()
+{
+    int evt = nrf_twim_event_check(p_twim, NRF_TWIM_EVENT_ERROR) ? 1 : 0;
+    auto err = p_twim->ERRORSRC;
+
+    if ( evt)
+        nrf_twim_event_clear(p_twim, NRF_TWIM_EVENT_ERROR);
+
+    if ( err)
+        p_twim->ERRORSRC = err;
+
+#if (DEVICE_DMESG_BUFFER_SIZE > 0)
+    if ( evt || err)
+    {
+        DMESG( "NRF52I2C error %d ERRORSRC %x", evt, (unsigned int) err);
+    }
+#endif
+}
+
+
 int NRF52I2C::waitForStop(int evt)
 {
     int res = DEVICE_OK;
@@ -118,6 +138,11 @@ int NRF52I2C::waitForStop(int evt)
             auto err = p_twim->ERRORSRC;
             p_twim->ERRORSRC = err;
 
+#if (DEVICE_DMESG_BUFFER_SIZE > 0)
+            DMESG( "NRF52I2C locked %d error %d ERRORSRC %x", locked, nrf_twim_event_check(p_twim, NRF_TWIM_EVENT_ERROR) ? 1 : 0, (unsigned int) err);
+            locked = 0;
+#endif
+
             nrf_twim_event_clear(p_twim, NRF_TWIM_EVENT_ERROR);
             nrf_twim_task_trigger(p_twim, NRF_TWIM_TASK_RESUME);
             nrf_twim_task_trigger(p_twim, NRF_TWIM_TASK_STOP);
@@ -125,7 +150,55 @@ int NRF52I2C::waitForStop(int evt)
 
             // Wait for STOP task to complete.
             // Ensures the I2C hardware is idle when the user code initiates a subsequent I2C transcaction.
-            while(!nrf_twim_event_check(p_twim, NRF_TWIM_EVENT_STOPPED));
+
+            bool stopped = false;
+
+            for ( int i = 0; i < 100; i++)
+            {
+                target_wait_us(10);
+                if (nrf_twim_event_check(p_twim, NRF_TWIM_EVENT_STOPPED))
+                {
+                    stopped = true;
+                    DMESG( "NRF52I2C stopped %d", i);
+                    break;
+                }
+            }
+
+            if ( !stopped)
+            {
+                // Disable, repeat constructor initialisation, enable.
+                // Takes about 30 microseconds
+#if (DEVICE_DMESG_BUFFER_SIZE > 0)
+                //CODAL_TIMESTAMP r0 = system_timer_current_time_us();
+                //DMESG( "NRF52I2C RECOVERING");
+                locked = 0;
+#endif
+
+                nrf_twim_disable(p_twim);
+
+                // Disable high-side pin drivers on SDA and SCL pins.
+                sda.setDriveMode(6);
+                scl.setDriveMode(6);
+
+                // Ensure all I2C drivers on the bus are fully reset
+                clearBus();
+
+                // put pins in input mode
+                sda.getDigitalValue(PullMode::Up);
+                scl.getDigitalValue(PullMode::Up);
+
+                target_wait_us(10);
+
+                nrf_twim_pins_set(p_twim, scl.name, sda.name);
+                nrf_twim_frequency_set(p_twim, NRF_TWIM_FREQ_100K);
+                nrf_twim_enable(p_twim);
+
+#if (DEVICE_DMESG_BUFFER_SIZE > 0)
+                //CODAL_TIMESTAMP r1 = system_timer_current_time_us();
+                //DMESG( "NRF52I2C RECOVERED %d us *******************", (int) (r1 - r0));
+                DMESG( "NRF52I2C RECOVERED *****************");
+#endif
+            }
             break;
         }
 
@@ -135,6 +208,7 @@ int NRF52I2C::waitForStop(int evt)
         locked++;
         if (p_twim->EVENTS_TXSTARTED && p_twim->TXD.MAXCNT == 0 && locked >= 100)
         {
+            DMESG( "NRF52I2C zero");
             res = DEVICE_OK;
             break;
         }
@@ -144,20 +218,34 @@ int NRF52I2C::waitForStop(int evt)
         // Appears to only occur under higher levels of background interrupt load.
         if (locked >= 100 && p_twim->EVENTS_LASTTX && (p_twim->SHORTS & NRF_TWIM_SHORT_LASTTX_SUSPEND_MASK) && !p_twim->EVENTS_SUSPENDED)
         {
+            DMESG( "NRF52I2C no suspend");
             p_twim->TASKS_SUSPEND = 1;
             locked = 0;
         }
 
         if (locked >= 100 && p_twim->EVENTS_LASTTX && (p_twim->SHORTS & NRF_TWIM_SHORT_LASTTX_STOP_MASK) && !p_twim->EVENTS_STOPPED)
         {
+            DMESG( "NRF52I2C no stop");
             p_twim->TASKS_STOP = 1;
             locked = 0;
         }
         target_wait_us(10);
     }
 
+#if (DEVICE_DMESG_BUFFER_SIZE > 0)
+    static int maxLocked = 0;
+    if ( locked > maxLocked)
+    {
+        maxLocked = locked;
+        //DMESG( "NRF52I2C maxLocked %d", maxLocked);
+    }
+    DMESG( "NRF52I2C locked %d max %d", locked, maxLocked);
+#endif
+
     if (minimumBusIdlePeriod)
         target_wait_us(minimumBusIdlePeriod);
+
+    checkError();
 
     return res;
 }
@@ -181,6 +269,9 @@ int NRF52I2C::waitForStop(int evt)
  */
 int NRF52I2C::write(uint16_t address, uint8_t *data, int len, bool repeated)
 {
+    DMESG( "NRF52I2C::write");
+    checkError();
+
     address = address >> 1;
 
     nrf_twim_address_set(p_twim, address);
@@ -229,6 +320,9 @@ int NRF52I2C::write(uint16_t address, uint8_t *data, int len, bool repeated)
  */
 int NRF52I2C::read(uint16_t address, uint8_t *data, int len, bool repeated)
 {
+    DMESG( "NRF52I2C::read");
+    checkError();
+
     address = address >> 1;
 
     nrf_twim_address_set(p_twim, address);


### PR DESCRIPTION
NRF52I2C::waitForStop can hang in the `while` loop https://github.com/lancaster-university/codal-nrf52/blob/master/source/NRF52I2C.cpp#L128.
This PR replaces the `while` loop with a short timeout `for` loop, and adds code to reset I2C if STOPPED doesn't happen.

Could we shorten the timeout in waitForStop, from the current 10 seconds (10us * 1 million) to, say, 50ms or 100ms? The longest successful operation I have seen is about 12ms.

Would it be useful to add NRF52I2C::setTimeout/getTimeout?
