### PR TITLE
Dynamic pin peripherals

### DIFF
--- a/inc/NRF52ADC.h
+++ b/inc/NRF52ADC.h
@@ -192,7 +192,7 @@ public:
 #define NRF52ADC_STATUS_PERIOD_CHANGED              0x01        // Indicates that the period of the ADC may have changed.
 
 
-class NRF52ADC : public CodalComponent
+class NRF52ADC : public CodalComponent, public PinPeripheral
 {
 
 public:
@@ -302,6 +302,15 @@ public:
      * @return DEVICE_OK on success, DEVICE_INVALID_PARAMETER if the given pin was not connected to the ADC.
      */
     int releaseChannel(Pin& pin);
+
+    /**
+    * Method to release the given pin from a peripheral, if already bound.
+    * Device drivers should override this method to disconnect themselves from the give pin
+    * to allow it to be used by a different peripheral.
+    *
+    * @param pin the Pin to be released
+    */
+    virtual int releasePin(Pin &pin) override;
 
     /**
       * Puts the component in (or out of) sleep (low power) mode.

--- a/inc/NRF52I2C.h
+++ b/inc/NRF52I2C.h
@@ -41,7 +41,7 @@ class NRF52I2C : public codal::I2C
 
     int waitForStop(int evt);
 protected:
-    NRF52Pin &sda, &scl;
+    NRF52Pin *sda, *scl;
     NRF_TWIM_Type *p_twim;
 public:
     /**
@@ -49,11 +49,34 @@ public:
      */
     NRF52I2C(NRF52Pin &sda, NRF52Pin &scl, NRF_TWIM_Type *device = NULL);
 
+    /**
+     * Destructor.
+     */
+    virtual ~NRF52I2C();
+
     /** Set the frequency of the I2C interface
      *
      * @param frequency The bus frequency in hertz
      */
     virtual int setFrequency(uint32_t frequency);
+
+    /**
+      * Change the pins used by this I2C peripheral to those provided.
+      *
+      * @param sda the Pin to use for the I2C SDA line.
+      * @param scl the Pin to use for the I2C SCL line.
+      * @return DEVICE_OK on success, or DEVICE_NOT_IMPLEMENTED / DEVICE_NOT_SUPPORTED if the request cannot be performed.
+      */
+    virtual int redirect(NRF52Pin &sda, NRF52Pin &scl);
+
+    /**
+      * Method to release the given pin from a peripheral, if already bound.
+      * Device drivers should override this method to disconnect themselves from the give pin
+      * to allow it to be used by a different peripheral.
+      *
+      * @param pin the Pin to be released
+      */
+    virtual int releasePin(Pin &pin) override;
 
     /**
     * Issues a standard, I2C command write to the I2C bus.

--- a/inc/NRF52PWM.h
+++ b/inc/NRF52PWM.h
@@ -18,7 +18,7 @@
 
 using namespace codal;
 
-class NRF52PWM : public CodalComponent, public DataSink
+class NRF52PWM : public CodalComponent, public DataSink, public PinPeripheral
 {
 
 private:
@@ -134,11 +134,17 @@ public:
     int
     connectPin(Pin &pin, int channel);
 
-    /**
-     * Disconnect the given pin from any PWM channels it has allocated.
-     */
-    int
-    disconnectPin(Pin &pin);
+   /**
+    * Method to release the given pin from a peripheral, if already bound.
+    * Device drivers should override this method to disconnect themselves from the give pin
+    * to allow it to be used by a different peripheral.
+    *
+    * @param pin the Pin to be released
+    */
+    virtual int releasePin(Pin &pin) override;
+
+    // Backward compat - deprecated.
+    int disconnectPin(Pin &pin);
 
     private:
     /**

--- a/inc/NRF52Pin.h
+++ b/inc/NRF52Pin.h
@@ -73,7 +73,7 @@ namespace codal
         static int8_t pwmChannelMap[NRF52PIN_PWM_CHANNEL_MAP_SIZE];
         static uint8_t lastUsedChannel;
 
-        void* obj;
+        PinPeripheral* obj;
 
 
         /**
@@ -109,6 +109,11 @@ namespace codal
         int disableEvents();
 
         public:
+
+        /**
+          * Record that a given peripheral has been connected to this pin.
+          */
+        virtual void connect(PinPeripheral &p, bool deleteOnRelease = false) override;
 
         /**
           * Disconnect any attached mBed IO from this pin.

--- a/inc/NRF52SPI.h
+++ b/inc/NRF52SPI.h
@@ -39,9 +39,9 @@ namespace codal
  */
 class NRF52SPI : public codal::SPI
 {
-    codal::Pin &mosi;
-    codal::Pin &miso;
-    codal::Pin &sck;
+    codal::Pin *mosi;
+    codal::Pin *miso;
+    codal::Pin *sck;
     nrf_spim_frequency_t freq;
     IRQn_Type IRQn;
     uint8_t mode;
@@ -119,6 +119,16 @@ public:
      */
     virtual int startTransfer(const uint8_t *txBuffer, uint32_t txSize, uint8_t *rxBuffer,
                          uint32_t rxSize, PVoidCallback doneHandler, void *arg);
+
+    /**
+      * Change the pins used by this I2C peripheral to those provided.
+      *
+      * @param mosi the Pin to use for the SPI input line.
+      * @param miso the Pin to use for the SPI output line.
+      * @param sclk the Pin to use for the SPI clock line.
+      * @return DEVICE_OK on success, or DEVICE_NOT_IMPLEMENTED / DEVICE_NOT_SUPPORTED if the request cannot be performed.
+      */
+    virtual int redirect(Pin &mosi, Pin &miso, Pin &sclk) override;
 };
 }
 

--- a/inc/ZSingleWireSerial.h
+++ b/inc/ZSingleWireSerial.h
@@ -28,6 +28,7 @@ namespace codal
 
         virtual void configureRxInterrupt(int enable);
         virtual void configureTxInterrupt(int enable);
+        virtual int releasePin(Pin &pin);
 
         ZSingleWireSerial(Pin& p);
 

--- a/source/NRF52ADC.cpp
+++ b/source/NRF52ADC.cpp
@@ -727,8 +727,9 @@ int NRF52ADC::releaseChannel(Pin& pin)
 int
 NRF52ADC::releasePin(Pin &pin)
 {
-    NRF52ADCChannel *c = getChannel(pin);
+    NRF52ADCChannel *c = getChannel(pin, false);
 
+    DMESG("NRF52ADC:: Releasing Pin");
     if (c != NULL)
     {
         // Release the ADC channel, and wait for it to be fully disabled before continuing.

--- a/source/NRF52ADC.cpp
+++ b/source/NRF52ADC.cpp
@@ -729,7 +729,6 @@ NRF52ADC::releasePin(Pin &pin)
 {
     NRF52ADCChannel *c = getChannel(pin, false);
 
-    DMESG("NRF52ADC:: Releasing Pin");
     if (c != NULL)
     {
         // Release the ADC channel, and wait for it to be fully disabled before continuing.

--- a/source/NRF52I2C.cpp
+++ b/source/NRF52I2C.cpp
@@ -72,7 +72,7 @@ void NRF52I2C::clearBus() {
         }
         sda->setDigitalValue(0);
         target_wait_us(4);
-        
+
         sda->setDigitalValue(1);
     }
 }
@@ -114,7 +114,6 @@ int NRF52I2C::setFrequency(uint32_t frequency)
  */
 int NRF52I2C::redirect(NRF52Pin &sda, NRF52Pin &scl)
 {
-    DMESG("I2C::redirect [this:%p] [this->sda:%p[%p]] [this->scl:%p[%p]] [sda:%p] [scl:%p]", this, &this->sda, this->sda, &this->scl, this->scl, &sda, &scl);
     reassignPin(&this->sda, &sda);
     reassignPin(&this->scl, &scl);
 

--- a/source/NRF52I2C.cpp
+++ b/source/NRF52I2C.cpp
@@ -114,6 +114,7 @@ int NRF52I2C::setFrequency(uint32_t frequency)
  */
 int NRF52I2C::redirect(NRF52Pin &sda, NRF52Pin &scl)
 {
+    DMESG("I2C::redirect [this:%p] [this->sda:%p[%p]] [this->scl:%p[%p]] [sda:%p] [scl:%p]", this, &this->sda, this->sda, &this->scl, this->scl, &sda, &scl);
     reassignPin(&this->sda, &sda);
     reassignPin(&this->scl, &scl);
 
@@ -121,6 +122,9 @@ int NRF52I2C::redirect(NRF52Pin &sda, NRF52Pin &scl)
 
     if (this->sda && this->scl)
     {
+        // Maintain our binding whilst we use the Pin:: IO operations...
+        setPinLock(true);
+
         // Disable high-side pin drivers on SDA and SCL pins.
         this->sda->setDriveMode(6);
         this->scl->setDriveMode(6);
@@ -129,8 +133,12 @@ int NRF52I2C::redirect(NRF52Pin &sda, NRF52Pin &scl)
         clearBus();
 
         // put pins in input mode
+
         this->sda->getDigitalValue(PullMode::Up);
         this->scl->getDigitalValue(PullMode::Up);
+
+        // We're done.
+        setPinLock(false);
     }
 
     target_wait_us(10);

--- a/source/NRF52Pin.cpp
+++ b/source/NRF52Pin.cpp
@@ -167,9 +167,17 @@ NRF52Pin::NRF52Pin(int id, PinNumber name, PinCapability capability) : codal::Pi
  */
 void NRF52Pin::connect(PinPeripheral &p, bool deleteOnRelease)
 {
-    if (obj != NULL)
-        disconnect();
+    DMESG("PIN::connect [this:%p] [obj:%p], [deleteOnRelease:%d]", this, obj, deleteOnRelease);
 
+    // If we're already attached to a peripheral and we're being asked to connect to a new one,
+    // then attempt to release the old peripheral.
+    if (obj && obj != &p)
+    {
+        DMESG("PIN:: Disconnecting [this:%p]", this);
+        disconnect();
+    }
+
+    DMESG("PIN:: Connected [this:%p] [obj:%p]", this, &p);
     Pin::connect(p, deleteOnRelease);
     obj = &p;
 }
@@ -184,7 +192,7 @@ void NRF52Pin::connect(PinPeripheral &p, bool deleteOnRelease)
 void NRF52Pin::disconnect()
 {
     // Detach any on chip peripherals attached to this pin.
-    if (obj)
+    if (obj && !obj->isPinLocked())
         obj->releasePin(*this);
 
     // If we have previously allocated a PWM channel to this pin through setAnalogValue(), mark that PWM channel as free for future allocation.

--- a/source/NRF52SPI.cpp
+++ b/source/NRF52SPI.cpp
@@ -152,6 +152,9 @@ void NRF52SPI::config()
 
     setPinLock(true);
 
+    DMESG("NRF52SPI: Updating CONFIG...");
+    nrf_spim_disable(p_spim);
+
     setDrive(sck);
     setDrive(mosi);
     uint32_t mosi_pin = 0xffffffff;
@@ -160,20 +163,24 @@ void NRF52SPI::config()
     if (mosi)
     {
         mosi->setDigitalValue(0);
+        mosi->setPull(mode <= 1 ? PullMode::Down : PullMode::Up);
         mosi_pin = mosi->name;
+        DMESG("NRF52SPI: Updating CONFIG... MOSI set: %p", mosi_pin);
     }
-    if (&miso)
+    if (miso)
     {
         miso->getDigitalValue();
+        miso->setPull(mode <= 1 ? PullMode::Down : PullMode::Up);
         miso_pin = miso->name;
+        DMESG("NRF52SPI: Updating CONFIG... MISO set: %p", miso_pin);
     }
-    if (&sck)
+    if (sck)
     {
         sck->setDigitalValue(mode <= 1 ? 0 : 1);
         sck_pin = sck->name;
+        DMESG("NRF52SPI: Updating CONFIG... SCK set: %p", sck_pin);
     }
 
-    nrf_spim_disable(p_spim);
     nrf_spim_pins_set(p_spim, sck_pin, mosi_pin, miso_pin);
     nrf_spim_frequency_set(p_spim, (nrf_spim_frequency_t)freq);
     nrf_spim_configure(p_spim, (nrf_spim_mode_t)mode, NRF_SPIM_BIT_ORDER_MSB_FIRST);
@@ -187,7 +194,7 @@ void NRF52SPI::config()
 
     setPinLock(true);
 
-    DMESG("SPI config done f=%p", freq);
+    DMESG("SPI config done f=%d", freq);
 }
 
 /** Set the frequency of the SPI interface

--- a/source/NRF52SPI.cpp
+++ b/source/NRF52SPI.cpp
@@ -152,7 +152,6 @@ void NRF52SPI::config()
 
     setPinLock(true);
 
-    DMESG("NRF52SPI: Updating CONFIG...");
     nrf_spim_disable(p_spim);
 
     setDrive(sck);
@@ -165,20 +164,17 @@ void NRF52SPI::config()
         mosi->setDigitalValue(0);
         mosi->setPull(mode <= 1 ? PullMode::Down : PullMode::Up);
         mosi_pin = mosi->name;
-        DMESG("NRF52SPI: Updating CONFIG... MOSI set: %p", mosi_pin);
     }
     if (miso)
     {
         miso->getDigitalValue();
         miso->setPull(mode <= 1 ? PullMode::Down : PullMode::Up);
         miso_pin = miso->name;
-        DMESG("NRF52SPI: Updating CONFIG... MISO set: %p", miso_pin);
     }
     if (sck)
     {
         sck->setDigitalValue(mode <= 1 ? 0 : 1);
         sck_pin = sck->name;
-        DMESG("NRF52SPI: Updating CONFIG... SCK set: %p", sck_pin);
     }
 
     nrf_spim_pins_set(p_spim, sck_pin, mosi_pin, miso_pin);
@@ -193,8 +189,6 @@ void NRF52SPI::config()
     NVIC_EnableIRQ(IRQn);
 
     setPinLock(true);
-
-    DMESG("SPI config done f=%d", freq);
 }
 
 /** Set the frequency of the SPI interface

--- a/source/NRF52SPI.cpp
+++ b/source/NRF52SPI.cpp
@@ -147,7 +147,10 @@ void NRF52SPI::config()
 {
     if (configured)
         return;
+
     configured = 1;
+
+    setPinLock(true);
 
     setDrive(sck);
     setDrive(mosi);
@@ -181,6 +184,8 @@ void NRF52SPI::config()
     NVIC_SetPriority(IRQn, 7);
     NVIC_ClearPendingIRQ(IRQn);
     NVIC_EnableIRQ(IRQn);
+
+    setPinLock(true);
 
     DMESG("SPI config done f=%p", freq);
 }

--- a/source/NRF52SPI.cpp
+++ b/source/NRF52SPI.cpp
@@ -135,14 +135,6 @@ int NRF52SPI::startTransfer(const uint8_t *txBuffer, uint32_t txSize, uint8_t *r
         return codal::SPI::startTransfer(txBuffer, txSize, rxBuffer, rxSize, doneHandler, arg);
 }
 
-static void setDrive(Pin *p)
-{
-    if (!p)
-        return;
-    NRF52Pin *pp = (NRF52Pin *)p;
-    pp->setHighDrive(true);
-}
-
 void NRF52SPI::config()
 {
     if (configured)
@@ -154,8 +146,6 @@ void NRF52SPI::config()
 
     nrf_spim_disable(p_spim);
 
-    setDrive(sck);
-    setDrive(mosi);
     uint32_t mosi_pin = 0xffffffff;
     uint32_t miso_pin = 0xffffffff;
     uint32_t sck_pin = 0xffffffff;

--- a/source/NRF52TouchSensor.cpp
+++ b/source/NRF52TouchSensor.cpp
@@ -75,7 +75,7 @@ int
 NRF52TouchSensor::addTouchButton(TouchButton *button)
 {
     TouchSensor::addTouchButton(button);
-    button->_pin.setDigitalValue(0);
+    button->setPinValue(0);
 
     // If we've just added the first button, ensure the timer is reset.
     if (numberOfButtons == 1)

--- a/source/ZSingleWireSerial.cpp
+++ b/source/ZSingleWireSerial.cpp
@@ -119,6 +119,25 @@ int ZSingleWireSerial::configureRx(int enable)
     return DEVICE_OK;
 }
 
+/**
+ * Method to release the given pin from a peripheral, if already bound.
+ * Device drivers should override this method to disconnect themselves from the give pin
+ * to allow it to be used by a different peripheral.
+ *
+ * @param pin the Pin to be released.
+ * @return DEVICE_OK on success, or DEVICE_NOT_IMPLEMENTED if unsupported, or DEVICE_INVALID_PARAMETER if the pin is not bound to this peripheral.
+ */
+int ZSingleWireSerial::releasePin(Pin &pin)
+{
+    configureRx(false);
+    configureTx(false);
+    
+    if (deleteOnRelease)
+        delete this;
+
+    return DEVICE_OK;
+}
+
 ZSingleWireSerial::ZSingleWireSerial(Pin& p) : DMASingleWireSerial(p)
 {
     uart = (NRF_UARTE_Type*)allocate_peripheral(PERI_MODE_UARTE);

--- a/source/ZSingleWireSerial.cpp
+++ b/source/ZSingleWireSerial.cpp
@@ -131,7 +131,7 @@ int ZSingleWireSerial::releasePin(Pin &pin)
 {
     configureRx(false);
     configureTx(false);
-    
+
     if (deleteOnRelease)
         delete this;
 


### PR DESCRIPTION
Introduces cleaner and more scalable interface for dynamic management of how pins are bound to peripherals.

Implements new interfaces for NRF52 peripherals as introduced in: https://github.com/lancaster-university/codal-core/pull/155

Resolves issues such as: https://github.com/lancaster-university/codal-microbit-v2/issues/226

Summary of changes:

- Implement PinPeripheral interface for all relevant NRF52 peripherals.
- Refactor connect()/disconnect() behaviour in NRF52Pin to reduce complexity and improve consistency.
- Introduce redirect() methods for NRF52SPI and NRF52I2C.
