### PR TITLE
Fix NeoPixel/WS2812B timing.

### DIFF
--- a/inc/WS2812B.h
+++ b/inc/WS2812B.h
@@ -32,9 +32,9 @@ DEALINGS IN THE SOFTWARE.
 
 #define WS2812B_BUFFER_SIZE         256
 #define WS2812B_PAD                 (0x8000)
-#define WS2812B_LOW                 (0x8000 | 6)
-#define WS2812B_HIGH                (0x8000 | 10)
-#define WS2812B_PWM_FREQ            500000
+#define WS2812B_LOW                 (0x8000 | 5) // 320ns
+#define WS2812B_HIGH                (0x8000 | 12) // 760ns
+#define WS2812B_PWM_FREQ            800000
 #define WS2812B_ZERO_PADDING        50
 
 /**


### PR DESCRIPTION
- Change frequency from 500kHz to 800kHz to match datasheet.
- Updating high & low timings to match make:code.

Tested on a variety of WS2812B strips as well as SK6812 RGB and RGBW strips and APA104 used by newer revisions of the Seeed Bit Kit micro:car.

Fixes https://github.com/lancaster-university/codal-microbit-v2/issues/294 (cc @microbit-carlos @finneyj )