### PR TITLE
[Clang compatibility] Update nrfx version to 2.1.0

### DIFF
--- a/asm/CortexContextSwitch.s
+++ b/asm/CortexContextSwitch.s
@@ -32,6 +32,11 @@
     .global save_context
     .global save_register_context
     .global restore_register_context
+    
+    .type swap_context, %function
+    .type save_context, %function
+    .type save_register_context, %function
+    .type restore_register_context, %function
 
 @ R0 Contains a pointer to the TCB of the fibre being scheduled out.
 @ R1 Contains a pointer to the base of the stack of the fibre being scheduled out.


### PR DESCRIPTION
nrfx update has been non-breaking during testing, v2.2.0 also seems fine, after this some fundamental changes seemed to happen with nrfx. Needed for |.section .isr_vector| -> |.section .isr_vector, "ax"| in mdk/gcc_startup_nrf52833.S. CortextContextSwitch.s was changed to reduce warnings when building using clang.