### PR TITLE
Apply workaround for nRF52833 errata 78 for timer high power consumption.

### DIFF
--- a/source/NRFLowLevelTimer.cpp
+++ b/source/NRFLowLevelTimer.cpp
@@ -115,6 +115,7 @@ int NRFLowLevelTimer::disable()
 {
     disableIRQ();
     timer->TASKS_STOP = 1;
+    timer->TASKS_SHUTDOWN = 1;
     return DEVICE_OK;
 }
 


### PR DESCRIPTION
When the timer is stopped using only the STOP task there can be an increased power consumption.

Workaround is to use the SHUTDOWN task after or instead STOP.

<img width="706" alt="image" src="https://github.com/lancaster-university/codal-nrf52/assets/29712657/7dde849b-d7c3-496a-9489-17138c910d93">
