### PR TITLE
Explicitly set SAADC channel config mode to single ended.

### DIFF
--- a/source/NRF52ADC.cpp
+++ b/source/NRF52ADC.cpp
@@ -273,6 +273,7 @@ void NRF52ADCChannel::configureGain()
         (gain << SAADC_CH_CONFIG_GAIN_Pos) |
         (SAADC_CH_CONFIG_REFSEL_VDD1_4 << SAADC_CH_CONFIG_REFSEL_Pos) |
         (SAADC_CH_CONFIG_TACQ_3us << SAADC_CH_CONFIG_TACQ_Pos) |
+        (SAADC_CH_CONFIG_MODE_SE << SAADC_CH_CONFIG_MODE_Pos) |
         (SAADC_CH_CONFIG_BURST_Disabled << SAADC_CH_CONFIG_BURST_Pos );
 }
 


### PR DESCRIPTION
The ADC SE (single ended) mode is set with value 0 at bit 20 in the CONFIG register for each channel.

<img width="779" alt="image" src="https://github.com/lancaster-university/codal-nrf52/assets/29712657/5be3c885-9bd3-4e96-b495-71c6d2d74dcd">
<img width="761" alt="image" src="https://github.com/lancaster-university/codal-nrf52/assets/29712657/bff731c4-7ec5-490d-9f14-58904dcdb168">


Before this PR the bit was left as zero, which does set the SE mode. This is the desired mode, as we want the differential mode to be GND.
So, this addition does not actually change the value set to `CH[n].CONFIG`, but it's better to be explicit about the configuration.

The values for the macros can be found in:
https://github.com/NordicSemiconductor/nrfx/blob/master/mdk/nrf52833_bitfields.h#L11953-L11957

```cpp
/* Bit 20 : Enable differential mode */
#define SAADC_CH_CONFIG_MODE_Pos (20UL) /*!< Position of MODE field. */
#define SAADC_CH_CONFIG_MODE_Msk (0x1UL << SAADC_CH_CONFIG_MODE_Pos) /*!< Bit mask of MODE field. */
#define SAADC_CH_CONFIG_MODE_SE (0UL) /*!< Single-ended, PSELN will be ignored, negative input to SAADC shorted to GND */
#define SAADC_CH_CONFIG_MODE_Diff (1UL) /*!< Differential */
```