### PR TITLE
Add more docs about updating nrfx submodule

### DIFF
--- a/nrfx_mods/README.md
+++ b/nrfx_mods/README.md
@@ -1,1 +1,15 @@
-This directory enables overwriting nrfx source files so we can instead use our own. nrfx is a submodule of this repository, but this location should be checked first, if any issues arise from this area to ensure default functionality hasn't been changed. Should the nrfx library ever be updated, the updates will need to be reflected here. Each modification file *should* contain information about the changes applied.
+# nrfx Mods
+
+This directory contains copies of nrfx source files, with needed modifications and explanations of what they are.
+
+nrfx is a submodule of this repository, but where applicable, the CMake file checks for files in this directory first. 
+
+## Updating nrfx
+
+Should the nrfx library ever be updated, any updates to the original files duplicated here should also be applied to these files.
+
+Each modified file here *should* contain information about the changes applied.
+
+Currently the https://github.com/microbit-foundation/codal-microbit-nrf5sdk/ library depends on this nrfx submodule.
+Because the nrf5SDK is no longer updated by Nordic, it has a hard dependency on nrfx being at v2.
+nrfx v3 introduces breaking changes that will likley impact the nRFSDK, so we might be stuck on v2.


### PR DESCRIPTION
Added a bit more info about restrictions updating the nrfx lib, as mentioned in:
- https://github.com/lancaster-university/codal-nrf52/pull/51#issuecomment-1719330846