### PR TITLE
Ensure all .cpp files have `using namespace codal`.

### DIFF
--- a/source/NRF52ADC.cpp
+++ b/source/NRF52ADC.cpp
@@ -29,6 +29,8 @@ DEALINGS IN THE SOFTWARE.
 #include "nrf.h"
 #include "cmsis.h"
 
+using namespace codal;
+
 // Calculation to determine the optimal usable space for a DMA buffer for the given number of channels
 #define NRF52ADC_DMA_ALIGNED_SIZED(c)   ((bufferSize - (bufferSize % (c * 2 * softwareOversample)))/2);
 

--- a/source/NRF52PDM.cpp
+++ b/source/NRF52PDM.cpp
@@ -26,6 +26,8 @@ DEALINGS IN THE SOFTWARE.
 #include "NRF52PDM.h"
 #include "nrf.h"
 
+using namespace codal;
+
 // Handle on the last (and probably only) instance of this class (NRF52 has only one PDM module)
 static NRF52PDM *nrf52_pdm_driver = NULL;
 

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -2,6 +2,8 @@
 #include "nrf.h"
 #include "cmsis.h"
 
+using namespace codal;
+
 #define  NRF52PWM_EMPTY_BUFFERSIZE  8
 static uint16_t emptyBuffer[NRF52PWM_EMPTY_BUFFERSIZE];
 

--- a/source/neopixel.cpp
+++ b/source/neopixel.cpp
@@ -4,6 +4,8 @@
 
 #include "neopixel.h"
 
+using namespace codal;
+
 #if CONFIG_ENABLED(HARDWARE_NEOPIXEL)
 
 void neopixel_send_buffer(Pin &pin, const uint8_t *ptr, int numBytes)
@@ -88,5 +90,5 @@ __attribute__((noinline)) void neopixel_send_buffer(Pin &pin, const uint8_t *ptr
 
 void neopixel_send_buffer(Pin &pin, ManagedBuffer buffer)
 {
-    neopixel_send_buffer(pin, &buffer[0], buffer.length());
+    codal::neopixel_send_buffer(pin, &buffer[0], buffer.length());
 }


### PR DESCRIPTION
As part of:
- https://github.com/lancaster-university/codal-microbit-v2/issues/240

Cannot remove all header files usage of `using namesapce` yet, as done in PR https://github.com/lancaster-university/codal-nrf52/pull/43, as that will affect other CODAL targets that might not have apply this type of patch yet.