### PR TITLE
Eliminate compiler warning

### DIFF
--- a/inc/NRF52TouchSensor.h
+++ b/inc/NRF52TouchSensor.h
@@ -75,7 +75,7 @@ namespace codal
         /**
          * Initiate a scan of the sensors.
          */
-        void onSampleEvent();
+        void onSampleEvent(Event) override;
 
     };
 }

--- a/source/NRF52TouchSensor.cpp
+++ b/source/NRF52TouchSensor.cpp
@@ -32,9 +32,10 @@ static NRF52TouchSensor *instance = NULL;
 
 static void touch_sense_irq(uint16_t mask)
 {
-    Event evt;
-    if (instance)
+    if (instance) {
+        Event evt;
         instance->onSampleEvent(evt);
+    }
 }
 
 /**

--- a/source/NRF52TouchSensor.cpp
+++ b/source/NRF52TouchSensor.cpp
@@ -32,8 +32,9 @@ static NRF52TouchSensor *instance = NULL;
 
 static void touch_sense_irq(uint16_t mask)
 {
+    Event evt;
     if (instance)
-        instance->onSampleEvent();
+        instance->onSampleEvent(evt);
 }
 
 /**
@@ -107,7 +108,7 @@ extern void calibrateTest(float sample);
  * Initiate a scan of the sensors.
  */
 void 
-NRF52TouchSensor::onSampleEvent()
+NRF52TouchSensor::onSampleEvent(Event)
 {
     int result;
 


### PR DESCRIPTION
NRF52TouchSensor::onSampleEvent() should take an Event as a parameter, because the base class does.