### PR TITLE
Bug fixes for rare glitches on WS2812B pixels (NeoPixels) and 030 errors on micro:bit V2 (1/3)

### DIFF
--- a/inc/NRF52PWM.h
+++ b/inc/NRF52PWM.h
@@ -32,6 +32,7 @@ namespace codal
 struct Nrf52PwmStats {
     // Debugging section - TODO evolve this into a simpler error flag
     // TODO work out how to init these once per first active.
+    // All times/durations are in cycles
     volatile uint32_t irqcount;               // counter
     volatile uint32_t irq0;                   // counter for SEQEND[0]
     volatile uint32_t irq1;                   // counter for SEQEND[1]
@@ -41,6 +42,8 @@ struct Nrf52PwmStats {
     volatile int    irqinactive;            // interrupts while !active
     volatile int    irqprestart;            // interrupts before pwm start (zero expected!)
     volatile int    irqpoststop;            // interrupts after a stop (one expected)
+    volatile uint32_t trypullcnt;           // counter
+    volatile uint32_t trypull_dur[IRQSTATLEN];  // durations
     volatile int    pwmstarts;              // PWM starts
     volatile uint32_t pwmstart_time[IRQSTATLEN];  // timestamps
     volatile int    pwmstops;               // PWM stops

--- a/inc/NRF52PWM.h
+++ b/inc/NRF52PWM.h
@@ -67,8 +67,6 @@ private:
     ManagedBuffer   buffer[2];              // The ManagedBuffers currently being used by the PWN hardware
     volatile int    errorFlag;              // TODO - finish this and work out how to retrieve it/clear it.
 
-    struct Nrf52PwmStats stats[4];           // statistics for debugging
-
     /**
      * Sets PWM hardware registers for chained buffers or simple one shot playback
      * 
@@ -77,6 +75,7 @@ private:
     void setPwmLoopInten(bool streamingMode);
 
 public:
+    struct Nrf52PwmStats stats[4];           // statistics for debugging
 
     // The stream component that is serving our data
     DataSource      &upstream;
@@ -103,7 +102,7 @@ public:
      * Check the statistics for anomalies and if any are found
      * DMESG print whole structure.
      */
-    void anomalyCheckStats();
+    void anomalyCheckStats(int bufcnt);
 
     /**
      * Callback provided when data is ready.

--- a/inc/NRF52PWM.h
+++ b/inc/NRF52PWM.h
@@ -100,14 +100,6 @@ private:
     struct Nrf52PwmStats stats[NRF52PWM_STATS];           // statistics per output for debugging TODO use define size
 #endif
 
-    // TOOD Move this to bottom
-    /**
-     * Sets PWM hardware registers for chained buffers or simple one shot playback
-     * 
-     * @ param streamingMode If true, buffers will be streamed in order they are received. If false, the most recent buffer supplied always takes prescedence.
-     */
-    void setPwmLoopInten(bool streamingMode);
-
 public:  
     // The stream component that is serving our data
     DataSource      &upstream;
@@ -237,6 +229,12 @@ public:
      */
     int tryPull(uint8_t b);
 
+    /**
+     * Sets PWM hardware registers for chained buffers or simple one shot playback
+     * 
+     * @ param streamingMode If true, buffers will be streamed in order they are received. If false, the most recent buffer supplied always takes prescedence.
+     */
+    void setPwmLoopInten(bool streamingMode);
 };
 } // namespace codal
 

--- a/inc/NRF52PWM.h
+++ b/inc/NRF52PWM.h
@@ -183,7 +183,7 @@ public:
     /**
      * Defines if the PWM module should maintain playout ordering of buffers, or always play the most recent buffer provided.
      * 
-     * @ param streamingMode If true, buffers will be streamed in order they are received. If false, the most recent buffer supplied always takes prescedence.
+     * @ param streamingMode If true, buffers will be streamed in order they are received. If false, the most recent buffer supplied always takes precedence.
      * @ param repeatOnEmpty If set to true, the last buffer received will be repeated when no data is available. If false, the PWM channel will be suspended.
      */
     void setStreamingMode(bool streamingMode, bool repeatOnEmpty = true);
@@ -230,7 +230,7 @@ public:
     /**
      * Sets PWM hardware registers for chained buffers or simple one shot playback
      * 
-     * @ param streamingMode If true, buffers will be streamed in order they are received. If false, the most recent buffer supplied always takes prescedence.
+     * @ param streamingMode If true, buffers will be streamed in order they are received. If false, the most recent buffer supplied always takes precedence.
      */
     void setPwmLoopInten(bool streamingMode);
 };

--- a/inc/NRF52PWM.h
+++ b/inc/NRF52PWM.h
@@ -22,8 +22,10 @@
 using namespace codal;
 #endif
 
+// #define NRF52PWM_STATS 4
+#if NRF52PWM_STATS > 0
 #define IRQSTATLEN 40 
-#define IRQSTATSCOUNT 4
+#endif
 
 #define NRF52PWM_ERROR_MALLOC      (1 << 0)
 #define NRF52PWM_ERROR_EARLYIRQ    (1 << 1)
@@ -44,6 +46,7 @@ namespace codal
         Stopped
     };
 
+#if NRF52PWM_STATS > 0
     struct Nrf52PwmStats {
     // Debugging section - TODO evolve this into a simpler error flag
     // TODO work out how to init these once per first active.
@@ -69,6 +72,7 @@ namespace codal
     volatile uint32_t irqtotalcountatstart; // record of irqtotalcount at start
     volatile uint32_t irqtotalcountatstop;  // record of irqtotalcount at stop
 };
+#endif
 
 class NRF52PWM : public CodalComponent, public DataSink, public PinPeripheral
 {
@@ -92,7 +96,11 @@ private:
     volatile uint16_t errorFlag;            // Error bitfield per stream
     volatile uint16_t errorFlagCumlative;   // Error bitfield all streams
     volatile PwmState state;
+#if NRF52PWM_STATS > 0
+    struct Nrf52PwmStats stats[NRF52PWM_STATS];           // statistics per output for debugging TODO use define size
+#endif
 
+    // TOOD Move this to bottom
     /**
      * Sets PWM hardware registers for chained buffers or simple one shot playback
      * 
@@ -101,8 +109,6 @@ private:
     void setPwmLoopInten(bool streamingMode);
 
 public:  
-    struct Nrf52PwmStats stats[4];           // statistics per output for debugging TODO use define size
-
     // The stream component that is serving our data
     DataSource      &upstream;
 
@@ -119,6 +125,7 @@ public:
       */
     NRF52PWM(NRF_PWM_Type *module, DataSource &source, float sampleRate = NRF52PWM_DEFAULT_FREQUENCY, uint16_t id = DEVICE_ID_SYSTEM_DAC);
 
+#if NRF52PWM_STATS > 0
     /**
      * Clear the statistics, typically used before starting to output PWM
      */
@@ -129,6 +136,7 @@ public:
      * DMESG print whole structure.
      */
     void anomalyCheckStats(int bufcnt);
+#endif
 
     /**
      * Callback provided when data is ready.

--- a/inc/NRF52PWM.h
+++ b/inc/NRF52PWM.h
@@ -45,7 +45,8 @@ struct Nrf52PwmStats {
     volatile int    pwmstops;               // PWM stops
     volatile int    preloadfails;           // failing to load both buffers before start
     volatile int    dataReadyAtStop;        // preserved dataReady value
-    volatile int    dataStarved;            // upstream failed to produce data in time
+    volatile int    nodata;                 // upstream failed to produce data in time
+    volatile uint32_t zero_time;              // stats zero timestamp
 };
 
 class NRF52PWM : public CodalComponent, public DataSink, public PinPeripheral
@@ -89,6 +90,12 @@ public:
      * Clear the statistics, typically used before starting to output PWM
      */
     void zeroStats();
+
+    /**
+     * Check the statistics for anomalies and if any are found
+     * DMESG print whole structure.
+     */
+    void anomalyCheckStats();
 
     /**
      * Callback provided when data is ready.

--- a/inc/NRF52PWM.h
+++ b/inc/NRF52PWM.h
@@ -39,6 +39,7 @@ struct Nrf52PwmStats {
     volatile uint32_t irq_times[IRQSTATLEN];      // timestamps
     volatile int    irq_seqend[IRQSTATLEN];       // bitmask for events
     volatile int    irqinactive;            // interrupts while !active
+    volatile int    irqprestart;            // interrupts before pwm start (zero expected!)
     volatile int    irqpoststop;            // interrupts after a stop (one expected)
     volatile int    pwmstarts;              // PWM starts
     volatile uint32_t pwmstart_time[IRQSTATLEN];  // timestamps

--- a/inc/NRF52PWM.h
+++ b/inc/NRF52PWM.h
@@ -29,15 +29,15 @@ class NRF52PWM : public CodalComponent, public DataSink, public PinPeripheral
 
 private:
     NRF_PWM_Type    &PWM;                   // The hardware PWM module used by this instance
-    bool            enabled;                // Determines if this PWM instance is enabled
-    bool            active;                 // Determines if this PWM instance is actively generating output
-    bool            streaming;              // Determines if the output is streamed, or discrete. Streamed mode maintains ordered, discrete repeats playout most recent data provided.
-    bool            repeatOnEmpty;          // Determines the behaviour of the PWM if a buffer underflow occurs.
-    int             dataReady;              // Count of the number of input buffers awaiting playout
-    float           sampleRate;
-    float           periodUs;               // Period between output samples, in microseconds
-    uint8_t         bufferPlaying;          // ID of the buffer currently being played (0 or 1). Output is hardware double buffered.
-    int8_t          stopStreamingAfterBuf;  // When stopping, the last buffer ID to play beforhand. -1 if no stop is scheduled.
+    volatile bool   enabled;                // Determines if this PWM instance is enabled
+    volatile bool   active;                 // Determines if this PWM instance is actively generating output
+    volatile bool   streaming;              // Determines if the output is streamed, or discrete. Streamed mode maintains ordered, discrete repeats playout most recent data provided.
+    volatile bool   repeatOnEmpty;          // Determines the behaviour of the PWM if a buffer underflow occurs.
+    volatile int    dataReady;              // Count of the number of input buffers awaiting playout
+    volatile float  sampleRate;
+    volatile float  periodUs;               // Period between output samples, in microseconds
+    volatile uint8_t bufferPlaying;          // ID of the buffer currently being played (0 or 1). Output is hardware double buffered.
+    volatile int8_t stopStreamingAfterBuf;  // When stopping, the last buffer ID to play beforhand. -1 if no stop is scheduled.
     ManagedBuffer   buffer[2];              // The ManagedBuffers currently being used by the PWN hardware
 
 public:

--- a/inc/NRF52PWM.h
+++ b/inc/NRF52PWM.h
@@ -68,6 +68,13 @@ private:
 
     struct Nrf52PwmStats stats[4];           // statistics for debugging
 
+    /**
+     * Sets PWM hardware registers for chained buffers or simple one shot playback
+     * 
+     * @ param streamingMode If true, buffers will be streamed in order they are received. If false, the most recent buffer supplied always takes prescedence.
+     */
+    void setPwmLoopInten(bool streamingMode);
+
 public:
 
     // The stream component that is serving our data

--- a/inc/NRF52PWM.h
+++ b/inc/NRF52PWM.h
@@ -48,15 +48,13 @@ namespace codal
 
 #if NRF52PWM_STATS > 0
     struct Nrf52PwmStats {
-    // Debugging section - TODO evolve this into a simpler error flag
-    // TODO work out how to init these once per first active.
     // All times/durations are in cycles
-    volatile uint32_t irqcount;               // counter
-    volatile uint32_t irq0;                   // counter for SEQEND[0]
-    volatile uint32_t irq1;                   // counter for SEQEND[1]
-    volatile uint32_t irqboth;                // counter for double event
-    volatile uint32_t irq_times[IRQSTATLEN];      // timestamps
-    volatile int    irq_seqend[IRQSTATLEN];       // bitmask for events
+    volatile uint32_t irqcount;             // counter
+    volatile uint32_t irq0;                 // counter for SEQEND[0]
+    volatile uint32_t irq1;                 // counter for SEQEND[1]
+    volatile uint32_t irqboth;              // counter for double event
+    volatile uint32_t irq_times[IRQSTATLEN];  // timestamps
+    volatile int    irq_seqend[IRQSTATLEN];   // bitmask for events
     volatile int    irqinactive;            // interrupts while !active
     volatile int    irqprestart;            // interrupts before pwm start (zero expected!)
     volatile int    irqpoststop;            // interrupts after a stop (one expected)
@@ -97,7 +95,7 @@ private:
     volatile uint16_t errorFlagCumlative;   // Error bitfield all streams
     volatile PwmState state;
 #if NRF52PWM_STATS > 0
-    struct Nrf52PwmStats stats[NRF52PWM_STATS];           // statistics per output for debugging TODO use define size
+    struct Nrf52PwmStats stats[NRF52PWM_STATS];  // statistics per stream for debugging
 #endif
 
 public:  

--- a/inc/NRF52PWM.h
+++ b/inc/NRF52PWM.h
@@ -22,8 +22,32 @@
 using namespace codal;
 #endif
 
+#define IRQSTATLEN 40 
+#define IRQSTATSCOUNT 4
+
+#define NRF52PWM_ERROR_SOMETHING 0x01
+
 namespace codal
 {
+struct Nrf52PwmStats {
+    // Debugging section - TODO evolve this into a simpler error flag
+    // TODO work out how to init these once per first active.
+    volatile int    irqcount;               // counter
+    volatile int    irq0;                   // counter for SEQEND[0]
+    volatile int    irq1;                   // counter for SEQEND[1]
+    volatile int    irqboth;                // counter for double event
+    volatile uint32_t irq_times[IRQSTATLEN];      // timestamps
+    volatile int    irq_seqend[IRQSTATLEN];       // bitmask for events
+    volatile int    irqinactive;            // interrupts while !active
+    volatile int    irqpoststop;            // interrupts after a stop (one expected)
+    volatile int    pwmstarts;              // PWM starts
+    volatile uint32_t pwmstart_time[IRQSTATLEN];  // timestamps
+    volatile int    pwmstops;               // PWM stops
+    volatile int    preloadfails;           // failing to load both buffers before start
+    volatile int    dataReadyAtStop;        // preserved dataReady value
+    volatile int    dataStarved;            // upstream failed to produce data in time
+};
+
 class NRF52PWM : public CodalComponent, public DataSink, public PinPeripheral
 {
 
@@ -36,9 +60,12 @@ private:
     volatile int    dataReady;              // Count of the number of input buffers awaiting playout
     volatile float  sampleRate;
     volatile float  periodUs;               // Period between output samples, in microseconds
-    volatile uint8_t bufferPlaying;          // ID of the buffer currently being played (0 or 1). Output is hardware double buffered.
+    volatile uint8_t bufferPlaying;         // ID of the buffer currently being played (0 or 1). Output is hardware double buffered.
     volatile int8_t stopStreamingAfterBuf;  // When stopping, the last buffer ID to play beforhand. -1 if no stop is scheduled.
     ManagedBuffer   buffer[2];              // The ManagedBuffers currently being used by the PWN hardware
+    volatile int    errorFlag;              // TODO - finish this and work out how to retrieve it/clear it.
+
+    struct Nrf52PwmStats stats[4];           // statistics for debugging
 
 public:
 
@@ -47,7 +74,6 @@ public:
 
     // Handles on the instances of this class used the three PWM modules (if present)
     static NRF52PWM *nrf52_pwm_driver[NRF52PWM_PWM_PERIPHERALS];
-    
 
     /**
       * Constructor for an instance of a PWM acting as a sink to a given (likely DMA enabled) datastream.
@@ -58,6 +84,11 @@ public:
       * @param id The id to use for the message bus when transmitting events.
       */
     NRF52PWM(NRF_PWM_Type *module, DataSource &source, float sampleRate = NRF52PWM_DEFAULT_FREQUENCY, uint16_t id = DEVICE_ID_SYSTEM_DAC);
+
+    /**
+     * Clear the statistics, typically used before starting to output PWM
+     */
+    void zeroStats();
 
     /**
      * Callback provided when data is ready.

--- a/inc/NRF52PWM.h
+++ b/inc/NRF52PWM.h
@@ -25,11 +25,26 @@ using namespace codal;
 #define IRQSTATLEN 40 
 #define IRQSTATSCOUNT 4
 
-#define NRF52PWM_ERROR_SOMETHING 0x01
+#define NRF52PWM_ERROR_MALLOC      (1 << 0)
+#define NRF52PWM_ERROR_EARLYIRQ    (1 << 1)
+#define NRF52PWM_ERROR_LATEIRQ     (1 << 2)
+#define NRF52PWM_ERROR_IDLEIRQ     (1 << 3)
+#define NRF52PWM_ERROR_MISMATCHIRQ (1 << 4)
+#define NRF52PWM_ERROR_MULTIEVENT  (1 << 5)
 
 namespace codal
 {
-struct Nrf52PwmStats {
+    enum class PwmState : uint8_t
+    {
+        Inactive = 0,
+        Priming,
+        SendingBuffers,
+        SendingLastBuffer,
+        Stopping,
+        Stopped
+    };
+
+    struct Nrf52PwmStats {
     // Debugging section - TODO evolve this into a simpler error flag
     // TODO work out how to init these once per first active.
     // All times/durations are in cycles
@@ -65,12 +80,18 @@ private:
     volatile bool   streaming;              // Determines if the output is streamed, or discrete. Streamed mode maintains ordered, discrete repeats playout most recent data provided.
     volatile bool   repeatOnEmpty;          // Determines the behaviour of the PWM if a buffer underflow occurs.
     volatile int    dataReady;              // Count of the number of input buffers awaiting playout
-    volatile float  sampleRate;
-    volatile float  periodUs;               // Period between output samples, in microseconds
+    volatile float  sampleRate;             // Requested frequency in hertz
+    volatile float  periodUs;               // Acutal period between output samples, in microseconds
     volatile uint8_t bufferPlaying;         // ID of the buffer currently being played (0 or 1). Output is hardware double buffered.
     volatile int8_t stopStreamingAfterBuf;  // When stopping, the last buffer ID to play beforhand. -1 if no stop is scheduled.
-    ManagedBuffer   buffer[2];              // The ManagedBuffers currently being used by the PWN hardware
-    volatile int    errorFlag;              // TODO - finish this and work out how to retrieve it/clear it.
+    ManagedBuffer   buffer[2];              // The ManagedBuffers currently being used by the PWM hardware
+    volatile uint32_t bufferCount;          // Buffers processed
+    volatile uint32_t irqTotalCount;        // Total count of interrupts
+    volatile uint32_t irqBeginTotalCount;   // Count before preloading buffers
+    volatile uint32_t irqStopTotalCount;    // Count at PWM stop
+    volatile uint16_t errorFlag;            // Error bitfield per stream
+    volatile uint16_t errorFlagCumlative;   // Error bitfield all streams
+    volatile PwmState state;
 
     /**
      * Sets PWM hardware registers for chained buffers or simple one shot playback
@@ -79,9 +100,8 @@ private:
      */
     void setPwmLoopInten(bool streamingMode);
 
-public:
-    volatile uint32_t irqtotalcount;         // total count of interrupts
-    struct Nrf52PwmStats stats[4];           // statistics per output for debugging
+public:  
+    struct Nrf52PwmStats stats[4];           // statistics per output for debugging TODO use define size
 
     // The stream component that is serving our data
     DataSource      &upstream;

--- a/inc/NRF52PWM.h
+++ b/inc/NRF52PWM.h
@@ -32,10 +32,10 @@ namespace codal
 struct Nrf52PwmStats {
     // Debugging section - TODO evolve this into a simpler error flag
     // TODO work out how to init these once per first active.
-    volatile int    irqcount;               // counter
-    volatile int    irq0;                   // counter for SEQEND[0]
-    volatile int    irq1;                   // counter for SEQEND[1]
-    volatile int    irqboth;                // counter for double event
+    volatile uint32_t irqcount;               // counter
+    volatile uint32_t irq0;                   // counter for SEQEND[0]
+    volatile uint32_t irq1;                   // counter for SEQEND[1]
+    volatile uint32_t irqboth;                // counter for double event
     volatile uint32_t irq_times[IRQSTATLEN];      // timestamps
     volatile int    irq_seqend[IRQSTATLEN];       // bitmask for events
     volatile int    irqinactive;            // interrupts while !active
@@ -47,7 +47,9 @@ struct Nrf52PwmStats {
     volatile int    preloadfails;           // failing to load both buffers before start
     volatile int    dataReadyAtStop;        // preserved dataReady value
     volatile int    nodata;                 // upstream failed to produce data in time
-    volatile uint32_t zero_time;              // stats zero timestamp
+    volatile uint32_t zero_time;            // stats zero timestamp
+    volatile uint32_t irqtotalcountatstart; // record of irqtotalcount at start
+    volatile uint32_t irqtotalcountatstop;  // record of irqtotalcount at stop
 };
 
 class NRF52PWM : public CodalComponent, public DataSink, public PinPeripheral
@@ -75,7 +77,8 @@ private:
     void setPwmLoopInten(bool streamingMode);
 
 public:
-    struct Nrf52PwmStats stats[4];           // statistics for debugging
+    volatile uint32_t irqtotalcount;         // total count of interrupts
+    struct Nrf52PwmStats stats[4];           // statistics per output for debugging
 
     // The stream component that is serving our data
     DataSource      &upstream;

--- a/inc/WS2812B.h
+++ b/inc/WS2812B.h
@@ -67,9 +67,9 @@ namespace codal
         WS2812B();
 
         /**
-         * Provide the next available ManagedBuffer to our downstream caller, if available.
+         * Provide the next lump of data to our downstream caller using an existing ManagerBuffer.
          */
-        virtual ManagedBuffer pull();
+        virtual void pull(ManagedBuffer &buffer);
 
         /**
          *  Determine the data format of the buffers streamed out of this component.

--- a/inc/WS2812B.h
+++ b/inc/WS2812B.h
@@ -82,6 +82,11 @@ namespace codal
         virtual void connect(DataSink &sink);
 
         /**
+         * Experimental: used by downstream caller to indicate all data has been sent.
+         */
+        virtual void dataWanted(int wanted);
+
+        /**
          *  Determine the maximum size of the buffers streamed out of this component.
          *  @return The maximum size of this component's output buffers, in bytes.
          */

--- a/inc/WS2812B.h
+++ b/inc/WS2812B.h
@@ -82,7 +82,7 @@ namespace codal
         virtual void connect(DataSink &sink);
 
         /**
-         * Experimental: used by downstream caller to indicate all data has been sent.
+         * Downstream caller uses this to indicate all data has been sent.
          */
         virtual void dataWanted(int wanted);
 

--- a/inc/WS2812B.h
+++ b/inc/WS2812B.h
@@ -49,11 +49,11 @@ namespace codal
         int             outputBufferSize;       // The maximum size of an output buffer.
 
         uint8_t         *data;                  // The input data being played (immutable)
-        int             samplesToSend;          // The length of the input buffer (mutable)
-        int             samplesSent;            // The number of bytes sent so far in the current request
+        volatile int    samplesToSend;          // The length of the input buffer (mutable)
+        volatile int    samplesSent;            // The number of bytes sent so far in the current request
 
         DataSink        *downstream;            // Pointer to our downstream component
-        bool            blockingPlayout;        // Set to true if a blocking playout has been requested
+        volatile bool   blockingPlayout;        // Set to true if a blocking playout has been requested
         FiberLock       lock;                   // used to synchronise blocking play calls.
 
         public:

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -151,7 +151,7 @@ void NRF52PWM::anomalyCheckStats(int bufcnt) {
 #endif
     if (s->irq0 + s->irq1 > s->irqcount || s->irqboth > 0)
         issues++;
-    if (s->irqinactive > 0 || s->irqprestart > 0 || s->irqpoststop > 0)
+    if (s->irqinactive > 0 || s->irqprestart > 0 || s->irqpoststop != 1)
         issues++; 
     if (s->pwmstarts != 1 || s->pwmstops != 1)
         issues++;

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -154,7 +154,7 @@ int NRF52PWM::setPeriodUs(float period)
     period_ticks = period_ticks >> prescaler;
     period_ticks = period_ticks << prescaler;
 
-    periodUs = period_ticks / (clock_frequency/1000000);
+    periodUs = (float)period_ticks / (clock_frequency/1000000);
     sampleRate = 1000000 / periodUs;
 
     return DEVICE_OK;

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -226,8 +226,13 @@ void NRF52PWM::anomalyCheckStats(int bufcnt) {
                       s->pwmstart_time[i], s->pwmstart_time[i] - s->zero_time);
             }
             for (int i = 0; i < IRQSTATLEN && s->irq_times[i] != 123456U; i++) {
-                DMESG("TS %u interval %d irq %d",
-                      s->irq_times[i], irq_intervals[i], s->irq_seqend[i]);
+                if (si == 0) {
+                    DMESG("TS %u interval %d irq %d",
+                          s->irq_times[i], irq_intervals[i], s->irq_seqend[i]);
+                } else {
+                    DMESG("TS %u irq %d",
+                          s->irq_times[i], s->irq_seqend[i]);
+                }
             }
             for (int i = 0; i < IRQSTATLEN && s->trypull_dur[i] != 0; i++) {
                 DMESG("TPDUR %u", s->trypull_dur[i]);

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -244,8 +244,16 @@ void NRF52PWM::setStreamingMode(bool streamingMode, bool repeatOnEmpty)
 {
     this->streaming = streamingMode;
     this->repeatOnEmpty = repeatOnEmpty;
+    setPwmLoopInten(streamingMode);
+}
 
-    if (streaming)
+/**
+ * Sets PWM hardware registers for chained buffers or simple one shot playback
+ * 
+ * @ param streamingMode If true, buffers will be streamed in order they are received. If false, the most recent buffer supplied always takes prescedence.
+ */
+void NRF52PWM::setPwmLoopInten(bool streamingMode) {
+    if (streamingMode)
     {
         PWM.LOOP = 1;
         PWM.SHORTS = PWM_SHORTS_LOOPSDONE_SEQSTART0_Enabled << PWM_SHORTS_LOOPSDONE_SEQSTART0_Pos; 
@@ -259,6 +267,7 @@ void NRF52PWM::setStreamingMode(bool streamingMode, bool repeatOnEmpty)
     }
 }
 
+
 /**
  * Pull a buffer into the given double buffer slot, if one is available.
  * @param b The buffer to fill (either 0 or 1)
@@ -270,6 +279,10 @@ int NRF52PWM::tryPull(uint8_t b)
     {
         PWM.TASKS_STOP = 1;
         while(PWM.EVENTS_STOPPED == 0);
+
+        // Attempt at workaround for stopping problem
+        // https://github.com/lancaster-university/codal-microbit-v2/issues/475
+        setPwmLoopInten(false);  // looping and interrupts off
 
         active = false;
         bufferPlaying = 0;
@@ -347,6 +360,10 @@ int NRF52PWM::pullRequest()
 
         // Check if we've preloaded both buffers
         if (bufferPlaying == 0) {
+            // Attempt at workaround for stopping problem
+            // https://github.com/lancaster-university/codal-microbit-v2/issues/475
+            setPwmLoopInten(streaming);
+
             PWM.TASKS_SEQSTART[0] = 1;
             stats[0].pwmstart_time[stats[0].pwmstarts] = DWT->CYCCNT;
             stats[0].pwmstarts++;

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -234,7 +234,7 @@ int NRF52PWM::tryPull(uint8_t b)
 
         // If a Pull request has been made since we decided to stop, start to fill up the
         // hardware double buffer so that we don't stall.
-        if(dataReady)
+        if (dataReady > 0)
         {
             dataReady--;
             pullRequest();
@@ -242,7 +242,7 @@ int NRF52PWM::tryPull(uint8_t b)
         return 0;
     }
 
-    if (dataReady){
+    if (dataReady > 0) {
         buffer[b] = upstream.pull();
         PWM.SEQ[b].PTR = (uint32_t) buffer[b].getBytes();
         PWM.SEQ[b].CNT = buffer[b].length() / 2;
@@ -290,7 +290,7 @@ int NRF52PWM::pullRequest()
         tryPull(bufferPlaying);
         bufferPlaying = (bufferPlaying + 1) % 2;
 
-        if (bufferPlaying !=0 && dataReady)
+        if (bufferPlaying !=0 && dataReady > 0)
         {
             tryPull(bufferPlaying);
             bufferPlaying = (bufferPlaying + 1) % 2;

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -10,6 +10,7 @@ using namespace codal;
 // #define  NRF52PWM_EMPTY_BUFFERSIZE 64
 // #define  NRF52PWM_EMPTY_BUFFERSIZE  4
 #define  NRF52PWM_EMPTY_BUFFERSIZE 12
+#define PWM_ZERO_DC 0x8000  // low output
 
 static uint16_t emptyBuffer[NRF52PWM_EMPTY_BUFFERSIZE];
 
@@ -51,7 +52,7 @@ NRF52PWM::NRF52PWM(NRF_PWM_Type *module, DataSource &source, float sampleRate, u
 
     // Clear empty buffer
     for (int i=0; i<NRF52PWM_EMPTY_BUFFERSIZE; i++)
-        emptyBuffer[i] = 0x8000;
+        emptyBuffer[i] = PWM_ZERO_DC;
 
     // Ensure PWM is currently disabled.
     disable();
@@ -180,10 +181,10 @@ void NRF52PWM::anomalyCheckStats(int bufcnt) {
                 irq_intervals[i] = (int32_t)time_to_irq;
                 if (irq_intervals[i] <= 0)
                     issues++;
-                
-                
-                if (irq_intervals[i] >= one_buffer_cyc + 560U + 1000U)
+                if (irq_intervals[i] >= (int)one_buffer_cyc + 560 + 1000)
                     issues++;
+
+                // TODO ponder reenablign this
                 // The first interrupts is often 9500 ish after start
                 // or 7900 ish - very very odd perhaps more is needed than CYCCNT
                 // if (s->irq_times[i] <= exp_event_cyc - 123U) {
@@ -432,8 +433,16 @@ int NRF52PWM::tryPull(uint8_t b)
         // The PWM doesn't seem to respond to changes in the SHORTS register while it's active...
         // instead, we provide an empty buffer to prevent partial repetition of any previous buffer.
         stats[0].nodata++;
-        PWM.SEQ[b].PTR = (uint32_t) emptyBuffer;
-        PWM.SEQ[b].CNT = (uint32_t) NRF52PWM_EMPTY_BUFFERSIZE;
+        // Zero the existing played data if buffer is larger
+        size_t bufferLen = buffer[b].length() / sizeof(uint16_t);
+        if (false && bufferLen > NRF52PWM_EMPTY_BUFFERSIZE) {  // TODO REMOVE false (a temp disable)
+            uint16_t *bufferData = (uint16_t *) &buffer[b][0];
+            for (size_t i = 0; i < bufferLen; i++)
+                bufferData[i] = PWM_ZERO_DC;
+        } else {
+            PWM.SEQ[b].PTR = (uint32_t) emptyBuffer;
+            PWM.SEQ[b].CNT = (uint32_t) NRF52PWM_EMPTY_BUFFERSIZE;
+        }
         stopStreamingAfterBuf = 1;
     }
   tryPullReturn:

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -394,6 +394,8 @@ int NRF52PWM::tryPull(uint8_t b)
         setPwmLoopInten(false);  // includes SHORTS off
         PWM.TASKS_STOP = 1;
         while(PWM.EVENTS_STOPPED == 0);
+        PWM.EVENTS_SEQEND[0] = PWM.EVENTS_SEQEND[1] = 0;
+
         stats[0].irqtotalcountatstop = irqtotalcount;
 
         active = false;

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -119,6 +119,7 @@ void NRF52PWM::zeroStats() {
         stats[0].irq_seqend[i] = -1;
     }
     stats[0].irqinactive = 0;
+    stats[0].irqprestart = 0;
     stats[0].irqpoststop = 0;
     stats[0].pwmstarts = stats[0].pwmstops = 0;
     stats[0].preloadfails = 0;
@@ -277,12 +278,12 @@ int NRF52PWM::tryPull(uint8_t b)
 {
     if (stopStreamingAfterBuf)
     {
+        // SHORTS must be disabled before STOP as "PWM could be immediately
+        // started again if the LOOPSDONE event occurred in the same peripheral
+        // clock cycle as the STOP task was triggered"
+        setPwmLoopInten(false);  // includes SHORTS off
         PWM.TASKS_STOP = 1;
         while(PWM.EVENTS_STOPPED == 0);
-
-        // Attempt at workaround for stopping problem
-        // https://github.com/lancaster-university/codal-microbit-v2/issues/475
-        setPwmLoopInten(false);  // looping and interrupts off
 
         active = false;
         bufferPlaying = 0;
@@ -290,7 +291,7 @@ int NRF52PWM::tryPull(uint8_t b)
 
         stats[0].pwmstops++;
 
-        upstream.dataWanted(DATASTREAM_NOT_WANTED);  // all the data has been sent
+        upstream.dataWanted(DATASTREAM_NOT_WANTED);  // all the data has been PWMed
 
         // If a Pull request has been made since we decided to stop, start to fill up the
         // hardware double buffer so that we don't stall.
@@ -360,10 +361,7 @@ int NRF52PWM::pullRequest()
 
         // Check if we've preloaded both buffers
         if (bufferPlaying == 0) {
-            // Attempt at workaround for stopping problem
-            // https://github.com/lancaster-university/codal-microbit-v2/issues/475
             setPwmLoopInten(streaming);
-
             PWM.TASKS_SEQSTART[0] = 1;
             stats[0].pwmstart_time[stats[0].pwmstarts] = DWT->CYCCNT;
             stats[0].pwmstarts++;
@@ -392,6 +390,9 @@ void NRF52PWM::irq()
     }
     if (stopStreamingAfterBuf) {
         stats[0].irqpoststop++;
+    }
+    if (stats[0].pwmstarts == 0) {
+        stats[0].irqprestart++;
     }
     // once the sequence has finished playing, load up the next buffer.
     if (PWM.EVENTS_SEQEND[0])

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -173,6 +173,7 @@ void NRF52PWM::anomalyCheckStats(int bufcnt) {
     if (s->preloadfails > 0 || s->dataReadyAtStop > 0 || s->nodata != 1)
         issues++;
 
+    // TODO - clock speed (MHz) and buffer size for maths
     uint32_t one_buffer_cyc = (uint32_t)(64 * 128 * periodUs);
     int32_t irq_intervals[IRQSTATLEN] = {0};
     if (s->pwmstarts > 0) {
@@ -191,9 +192,11 @@ void NRF52PWM::anomalyCheckStats(int bufcnt) {
                 if (irq_intervals[i] >= (int)one_buffer_cyc + 560 + 1000)
                     issues++;
 
-                // TODO ponder reenablign this
+                // TODO ponder re-enabling this
                 // The first interrupts is often 9500 ish after start
-                // or 7900 ish - very very odd perhaps more is needed than CYCCNT
+                // or 7900 ish which seems impossible as min time should
+                // be 128 * 1.25 * 64 = 10240 cycles
+                // very very odd perhaps CYCCNT + somethnigelse is needed
                 // if (s->irq_times[i] <= exp_event_cyc - 123U) {
                 //     issues++;
                 // } else if (s->irq_times[i] >= exp_event_cyc + 2345U) {
@@ -204,7 +207,6 @@ void NRF52PWM::anomalyCheckStats(int bufcnt) {
             }
         }
     }
-    // TODO - get buffer size from somewhere + clock speed for 64MHz
     uint32_t risky_cyc = (uint32_t)(one_buffer_cyc * 0.90f);
     for (int i = 0; i < IRQSTATLEN && s->trypull_dur[i] != 0; i++) {
         
@@ -215,14 +217,9 @@ void NRF52PWM::anomalyCheckStats(int bufcnt) {
     }
 
     int testtrigger = 0;
-    // if (DWT->CYCCNT % 1000 < 10)   // TODO - REMOVE JUST FOR TESTING
+    // if (DWT->CYCCNT % 1000 < 10)
     //    testtrigger++;
 
-    // if (issues > 0) {
-    //     system_timer_wait_us(2000);  // TODO - remove, temporary to make more visible on logic analyzer
-    //     return;
-    // }
-     
     if (issues > 0 || testtrigger) {
         DMESG("NRF52PWM anomalyCheckStart(%d) issues=%d", bufcnt, issues);
         for (int si = NRF52PWM_STATS - 1; si >= 0; si--) {

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -42,6 +42,7 @@ NRF52PWM::NRF52PWM(NRF_PWM_Type *module, DataSource &source, float sampleRate, u
     this->repeatOnEmpty = true;
     this->bufferPlaying = 0;
     this->stopStreamingAfterBuf = 0;
+    this->irqtotalcount = 0;
 
     // Clear empty buffer
     for (int i=0; i<NRF52PWM_EMPTY_BUFFERSIZE; i++)
@@ -126,7 +127,7 @@ void NRF52PWM::zeroStats() {
     stats[0].preloadfails = 0;
     stats[0].dataReadyAtStop = 123456;
     stats[0].nodata = 0;
-
+    stats[0].irqtotalcountatstart = stats[0].irqtotalcountatstop = 0;
     stats[0].zero_time = DWT->CYCCNT;
 }
 
@@ -139,8 +140,15 @@ void NRF52PWM::anomalyCheckStats(int bufcnt) {
     struct Nrf52PwmStats *s = &stats[0];
     int issues = 0;
 
-    if (s->irqcount != bufcnt)
+    if (s->irqcount != (uint32_t)bufcnt)
         issues++;
+    if (s->irqtotalcountatstop != s->irqtotalcountatstart + s->irqcount)
+        issues++;
+#if IRQSTATSCOUNT > 1 
+    // Look for interrupts occuring while PWM should be not running
+    if (stats[1].irqtotalcountatstop != s->irqtotalcountatstart)
+        issues++;
+#endif
     if (s->irq0 + s->irq1 > s->irqcount || s->irqboth > 0)
         issues++;
     if (s->irqinactive > 0 || s->irqprestart > 0 || s->irqpoststop > 0)
@@ -321,6 +329,7 @@ int NRF52PWM::tryPull(uint8_t b)
         PWM.TASKS_STOP = 1;
         while(PWM.EVENTS_STOPPED == 0);
         disable();
+        stats[0].irqtotalcountatstop = irqtotalcount;
 
         active = false;
         bufferPlaying = 0;
@@ -386,6 +395,7 @@ int NRF52PWM::pullRequest()
     if (streaming && !active)
     {
         active = true;
+        stats[0].irqtotalcountatstart = irqtotalcount;
 
         tryPull(bufferPlaying);
         bufferPlaying = (bufferPlaying + 1) % 2;
@@ -420,6 +430,7 @@ void NRF52PWM::irq()
     stats[0].irq_times[stats[0].irqcount % IRQSTATLEN] = DWT->CYCCNT;
     stats[0].irq_seqend[stats[0].irqcount % IRQSTATLEN] = (PWM.EVENTS_SEQEND[1] ? 0b10 : 0) + (PWM.EVENTS_SEQEND[0] ? 0b01 : 0);
     stats[0].irqcount++;
+    irqtotalcount++;  // this counter will eventually wrap
     if (PWM.EVENTS_SEQEND[0] && PWM.EVENTS_SEQEND[1]) {
         stats[0].irqboth++;
     }

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -180,11 +180,17 @@ void NRF52PWM::anomalyCheckStats(int bufcnt) {
                 irq_intervals[i] = (int32_t)time_to_irq;
                 if (irq_intervals[i] <= 0)
                     issues++;
-                if (s->irq_times[i] <= exp_event_cyc - 123U) {
+                
+                
+                if (irq_intervals[i] >= one_buffer_cyc + 560U + 1000U)
                     issues++;
-                } else if (s->irq_times[i] >= exp_event_cyc + 2345U) {
-                    issues++;
-                }
+                // The first interrupts is often 9500 ish after start
+                // or 7900 ish - very very odd perhaps more is needed than CYCCNT
+                // if (s->irq_times[i] <= exp_event_cyc - 123U) {
+                //     issues++;
+                // } else if (s->irq_times[i] >= exp_event_cyc + 2345U) {
+                //     issues++;
+                // }
                 prev_event_cyc = s->irq_times[i];
                 exp_event_cyc += one_buffer_cyc;
             }

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -123,8 +123,26 @@ void NRF52PWM::zeroStats() {
     stats[0].pwmstarts = stats[0].pwmstops = 0;
     stats[0].preloadfails = 0;
     stats[0].dataReadyAtStop = 123456;
-    stats[0].dataStarved = 0;
+    stats[0].nodata = 0;
+
+    stats[0].zero_time = DWT->CYCCNT;
 }
+
+
+/**
+  * Check the statistics for anomalies and if any are found
+  * DMESG print whole structure.
+  */
+void NRF52PWM::anomalyCheckStats() {
+   int issues = 0;
+
+   // TODO add checks
+
+   if (issues > 0) {
+      // TODO DMESG printing of everything
+   }
+}
+
 
 /**
  * Determine the DAC playback sample rate to the given frequency.
@@ -288,7 +306,7 @@ int NRF52PWM::tryPull(uint8_t b)
     {
         // The PWM doesn't seem to respond to changes in the SHORTS register while it's active...
         // instead, we provide an empty buffer to prevent partial repetition of any previous buffer.
-        stats[0].dataStarved++;
+        stats[0].nodata++;
         PWM.SEQ[b].PTR = (uint32_t) emptyBuffer;
         PWM.SEQ[b].CNT = (uint32_t) NRF52PWM_EMPTY_BUFFERSIZE;
         stopStreamingAfterBuf = 1;

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -475,6 +475,7 @@ int NRF52PWM::pullRequest()
     {
         active = true;
         stats[0].irqtotalcountatstart = irqtotalcount;
+        upstream.dataWanted(DATASTREAM_WANTED);
 
         tryPull(bufferPlaying);
         bufferPlaying = (bufferPlaying + 1) % 2;

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -164,19 +164,34 @@ void NRF52PWM::anomalyCheckStats(int bufcnt) {
         issues++;
     if (s->preloadfails > 0 || s->dataReadyAtStop > 0 || s->nodata != 1)
         issues++;
+
+    uint32_t one_buffer_cyc = (uint32_t)(64 * 128 * periodUs);
+    int32_t irq_intervals[IRQSTATLEN] = {0};
     if (s->pwmstarts > 0) {
         // The wrapping time values require care with maths and comparisons
         uint32_t z_to_ps = s->pwmstart_time[0] - s->zero_time;
         if ((int32_t)z_to_ps <= 0)
             issues++;
         if (s->irqcount > 0) {
-            uint32_t ps_to_irq = s->irq_times[0] - s->pwmstart_time[0];
-            if ((int32_t)ps_to_irq <= 0)
-                issues++;
+            uint32_t prev_event_cyc = s->pwmstart_time[0];
+            uint32_t exp_event_cyc = prev_event_cyc + one_buffer_cyc;
+            for (size_t i = 0; i < s->irqcount; i++) {
+                uint32_t time_to_irq = s->irq_times[i] - prev_event_cyc;
+                irq_intervals[i] = (int32_t)time_to_irq;
+                if (irq_intervals[i] <= 0)
+                    issues++;
+                if (s->irq_times[i] <= exp_event_cyc - 123U) {
+                    issues++;
+                } else if (s->irq_times[i] >= exp_event_cyc + 2345U) {
+                    issues++;
+                }
+                prev_event_cyc = s->irq_times[i];
+                exp_event_cyc += one_buffer_cyc;
+            }
         }
     }
     // TODO - get buffer size from somewhere + clock speed for 64MHz
-    uint32_t risky_cyc = (uint32_t)(64 * 128 * periodUs * 0.90f);
+    uint32_t risky_cyc = (uint32_t)(one_buffer_cyc * 0.90f);
     for (int i = 0; i < IRQSTATLEN && s->trypull_dur[i] != 0; i++) {
         
         if (s->trypull_dur[i] >= risky_cyc) {
@@ -207,10 +222,12 @@ void NRF52PWM::anomalyCheckStats(int bufcnt) {
                   s->trypullcnt, s->preloadfails, s->dataReadyAtStop, s->nodata);
             DMESG("TS %u zero", s->zero_time);
             for (int i = 0; i < IRQSTATLEN && s->pwmstart_time[i] != 123456U; i++) {
-                DMESG("TS %u pwmstart", s->pwmstart_time[i]);
+                DMESG("TS %u pwmstart fromzero %d",
+                      s->pwmstart_time[i], s->pwmstart_time[i] - s->zero_time);
             }
             for (int i = 0; i < IRQSTATLEN && s->irq_times[i] != 123456U; i++) {
-                DMESG("TS %u irq %d", s->irq_times[i], s->irq_seqend[i]);
+                DMESG("TS %u interval %d irq %d",
+                      s->irq_times[i], irq_intervals[i], s->irq_seqend[i]);
             }
             for (int i = 0; i < IRQSTATLEN && s->trypull_dur[i] != 0; i++) {
                 DMESG("TPDUR %u", s->trypull_dur[i]);

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -102,6 +102,31 @@ NRF52PWM::NRF52PWM(NRF_PWM_Type *module, DataSource &source, float sampleRate, u
 }
 
 /**
+  * Clear the statistics, typically used before starting to output PWM
+  * This is flawed due to not zeroing historical data
+  */
+void NRF52PWM::zeroStats() {
+    // copy values to make history
+    for (int i = IRQSTATSCOUNT - 1; i >= 0; i--) {
+       memcpy(&stats[i], &stats[i - 1], sizeof(stats[0]));
+    }
+
+    // zero out current values
+    stats[0].irqcount = stats[0].irq0 = stats[0].irq1 = stats[0].irqboth = 0;
+    for (int i = 0; i < IRQSTATLEN; i++) {
+        stats[0].irq_times[i] = 123456U;
+        stats[0].pwmstart_time[i] = 123456U;
+        stats[0].irq_seqend[i] = -1;
+    }
+    stats[0].irqinactive = 0;
+    stats[0].irqpoststop = 0;
+    stats[0].pwmstarts = stats[0].pwmstops = 0;
+    stats[0].preloadfails = 0;
+    stats[0].dataReadyAtStop = 123456;
+    stats[0].dataStarved = 0;
+}
+
+/**
  * Determine the DAC playback sample rate to the given frequency.
  * @return the current sample rate.
  */
@@ -231,10 +256,14 @@ int NRF52PWM::tryPull(uint8_t b)
         active = false;
         bufferPlaying = 0;
         stopStreamingAfterBuf = 0;
+
+        stats[0].pwmstops++;
+
         upstream.dataWanted(DATASTREAM_NOT_WANTED);  // all the data has been sent
 
         // If a Pull request has been made since we decided to stop, start to fill up the
         // hardware double buffer so that we don't stall.
+        stats[0].dataReadyAtStop = dataReady;
         if (dataReady > 0)
         {
             dataReady--;
@@ -259,6 +288,7 @@ int NRF52PWM::tryPull(uint8_t b)
     {
         // The PWM doesn't seem to respond to changes in the SHORTS register while it's active...
         // instead, we provide an empty buffer to prevent partial repetition of any previous buffer.
+        stats[0].dataStarved++;
         PWM.SEQ[b].PTR = (uint32_t) emptyBuffer;
         PWM.SEQ[b].CNT = (uint32_t) NRF52PWM_EMPTY_BUFFERSIZE;
         stopStreamingAfterBuf = 1;
@@ -298,10 +328,14 @@ int NRF52PWM::pullRequest()
         }
 
         // Check if we've preloaded both buffers
-        if (bufferPlaying == 0)
+        if (bufferPlaying == 0) {
             PWM.TASKS_SEQSTART[0] = 1;
-        else
+            stats[0].pwmstart_time[stats[0].pwmstarts] = DWT->CYCCNT;
+            stats[0].pwmstarts++;
+        } else {
             active = false;
+            stats[0].preloadfails++;
+        }
     }
 
     return DEVICE_OK;
@@ -312,11 +346,24 @@ int NRF52PWM::pullRequest()
  */
 void NRF52PWM::irq()
 {
+    stats[0].irq_times[stats[0].irqcount % IRQSTATLEN] = DWT->CYCCNT;
+    stats[0].irq_seqend[stats[0].irqcount % IRQSTATLEN] = (PWM.EVENTS_SEQEND[1] ? 0b10 : 0) + (PWM.EVENTS_SEQEND[0] ? 0b01 : 0);
+    stats[0].irqcount++;
+    if (PWM.EVENTS_SEQEND[0] && PWM.EVENTS_SEQEND[1]) {
+        stats[0].irqboth++;
+    }
+    if (!active) {
+        stats[0].irqinactive++;
+    }
+    if (stopStreamingAfterBuf) {
+        stats[0].irqpoststop++;
+    }
     // once the sequence has finished playing, load up the next buffer.
     if (PWM.EVENTS_SEQEND[0])
     {
         bufferPlaying = 1;
         tryPull(0);
+        stats[0].irq0++;
 
         PWM.EVENTS_SEQEND[0] = 0;
     }
@@ -325,6 +372,7 @@ void NRF52PWM::irq()
     {
         bufferPlaying = 0;
         tryPull(1);
+        stats[0].irq1++;
 
         PWM.EVENTS_SEQEND[1] = 0;
     }

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -337,6 +337,7 @@ void NRF52PWM::setPwmLoopInten(bool streamingMode) {
  */
 int NRF52PWM::tryPull(uint8_t b)
 {
+    int filled = 0;
     if (stopStreamingAfterBuf)
     {
         // SHORTS must be disabled before STOP as "PWM could be immediately
@@ -363,7 +364,7 @@ int NRF52PWM::tryPull(uint8_t b)
             dataReady--;
             pullRequest();
         }
-        return 0;
+        goto tryPullReturn;
     }
 
     if (dataReady > 0) { 
@@ -373,7 +374,8 @@ int NRF52PWM::tryPull(uint8_t b)
 
         dataReady--;
 
-        return 1;
+        filled = 1;
+        goto tryPullReturn;
     }
 
     // If we're in active streaming mode, and have requested a buffer and failed to get one, we have an underflow.
@@ -387,7 +389,9 @@ int NRF52PWM::tryPull(uint8_t b)
         PWM.SEQ[b].CNT = (uint32_t) NRF52PWM_EMPTY_BUFFERSIZE;
         stopStreamingAfterBuf = 1;
     }
-    return 0;
+  tryPullReturn:
+
+    return filled;
 }
 
 /**

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -146,7 +146,7 @@ void NRF52PWM::anomalyCheckStats(int bufcnt) {
         issues++;
 #if IRQSTATSCOUNT > 1 
     // Look for interrupts occuring while PWM should be not running
-    if (stats[1].irqtotalcountatstop != s->irqtotalcountatstart)
+    if (s->irqtotalcountatstart != 0 && stats[1].irqtotalcountatstop != s->irqtotalcountatstart)
         issues++;
 #endif
     if (s->irq0 + s->irq1 > s->irqcount || s->irqboth > 0)
@@ -162,10 +162,11 @@ void NRF52PWM::anomalyCheckStats(int bufcnt) {
     if (s->pwmstarts > 0 && s->irqcount > 0 && s->pwmstart_time[0] > s->irq_times[0])
         issues++;
 
-    if (DWT->CYCCNT % 1000 < 10)   // TODO - REMOVE JUST FOR TESTING
-        issues++;
+    int testtrigger = 0;
+    // if (DWT->CYCCNT % 1000 < 10)   // TODO - REMOVE JUST FOR TESTING
+    //    testtrigger++;
 
-    if (issues > 0) {
+    if (issues > 0 || testtrigger) {
         DMESG("NRF52PWM anomalyCheckStart(%d) issues=%d", bufcnt, issues);
         for (int si = IRQSTATSCOUNT - 1; si >= 0; si--) {
             struct Nrf52PwmStats *s = &stats[si];
@@ -425,13 +426,10 @@ int NRF52PWM::pullRequest()
  */
 void NRF52PWM::irq()
 {
-    stats[0].irq_times[stats[0].irqcount % IRQSTATLEN] = DWT->CYCCNT;
-    stats[0].irq_seqend[stats[0].irqcount % IRQSTATLEN] = (PWM.EVENTS_SEQEND[1] ? 0b10 : 0) + (PWM.EVENTS_SEQEND[0] ? 0b01 : 0);
+    size_t statidx = stats[0].irqcount % IRQSTATLEN;
+    stats[0].irq_times[statidx] = DWT->CYCCNT;
     stats[0].irqcount++;
     irqtotalcount++;  // this counter will eventually wrap
-    if (PWM.EVENTS_SEQEND[0] && PWM.EVENTS_SEQEND[1]) {
-        stats[0].irqboth++;
-    }
     if (!active) {
         stats[0].irqinactive++;
     }
@@ -441,8 +439,10 @@ void NRF52PWM::irq()
     if (stats[0].pwmstarts == 0) {
         stats[0].irqprestart++;
     }
+
     // once the sequence has finished playing, load up the next buffer.
-    if (PWM.EVENTS_SEQEND[0])
+    bool end0 = PWM.EVENTS_SEQEND[0];
+    if (end0)
     {
         bufferPlaying = 1;
         tryPull(0);
@@ -451,7 +451,8 @@ void NRF52PWM::irq()
         PWM.EVENTS_SEQEND[0] = 0;
     }
 
-    if (PWM.EVENTS_SEQEND[1])
+    bool end1 = PWM.EVENTS_SEQEND[1];
+    if (end1)
     {
         bufferPlaying = 0;
         tryPull(1);
@@ -459,6 +460,11 @@ void NRF52PWM::irq()
 
         PWM.EVENTS_SEQEND[1] = 0;
     }
+
+    if (end0 && end1) {
+        stats[0].irqboth++;
+    }
+    stats[0].irq_seqend[statidx] = (end1 ? 0b10 : 0) + (end0 ? 0b01 : 0);
 }
 
 /**

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -304,8 +304,8 @@ int NRF52PWM::tryPull(uint8_t b)
         return 0;
     }
 
-    if (dataReady > 0) {
-        buffer[b] = upstream.pull();
+    if (dataReady > 0) { 
+        upstream.pull(buffer[b]);
         PWM.SEQ[b].PTR = (uint32_t) buffer[b].getBytes();
         PWM.SEQ[b].CNT = buffer[b].length() / 2;
 

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -48,7 +48,13 @@ NRF52PWM::NRF52PWM(NRF_PWM_Type *module, DataSource &source, float sampleRate, u
     this->repeatOnEmpty = true;
     this->bufferPlaying = 0;
     this->stopStreamingAfterBuf = 0;
-    this->irqtotalcount = 0;
+    this->bufferCount = 0;
+    this->irqTotalCount = 0;
+    this->irqBeginTotalCount = 0;
+    this->irqStopTotalCount = 0;
+    this->errorFlag = 0;
+    this->errorFlagCumlative = 0;
+    this->state = PwmState::Inactive;
 
     // Clear empty buffer
     for (int i=0; i<NRF52PWM_EMPTY_BUFFERSIZE; i++)
@@ -388,6 +394,7 @@ int NRF52PWM::tryPull(uint8_t b)
 
     if (stopStreamingAfterBuf)
     {
+        state = PwmState::Stopping;
         // SHORTS must be disabled before STOP as "PWM could be immediately
         // started again if the LOOPSDONE event occurred in the same peripheral
         // clock cycle as the STOP task was triggered"
@@ -395,12 +402,18 @@ int NRF52PWM::tryPull(uint8_t b)
         PWM.TASKS_STOP = 1;
         while(PWM.EVENTS_STOPPED == 0);
         PWM.EVENTS_SEQEND[0] = PWM.EVENTS_SEQEND[1] = 0;
+        state = PwmState::Stopped;
+        irqStopTotalCount = irqTotalCount;
+        uint32_t irqs = irqStopTotalCount - irqBeginTotalCount;
+        if (irqs != bufferCount)
+            errorFlag |= NRF52PWM_ERROR_MISMATCHIRQ;
 
-        stats[0].irqtotalcountatstop = irqtotalcount;
+        stats[0].irqtotalcountatstop = irqTotalCount;
 
         active = false;
         bufferPlaying = 0;
         stopStreamingAfterBuf = 0;
+        errorFlagCumlative |= errorFlag;
 
         stats[0].pwmstops++;
 
@@ -421,6 +434,7 @@ int NRF52PWM::tryPull(uint8_t b)
         upstream.pull(buffer[b]);
         PWM.SEQ[b].PTR = (uint32_t) buffer[b].getBytes();
         PWM.SEQ[b].CNT = buffer[b].length() / 2;
+        bufferCount++;
 
         dataReady--;
 
@@ -432,6 +446,7 @@ int NRF52PWM::tryPull(uint8_t b)
     // Streaming mode is double buffered, so schedule ourself to stop after the next buffer is played, if we're so configured.
     if (streaming && active && !repeatOnEmpty)
     {
+        state = PwmState::SendingLastBuffer;
         // The PWM doesn't seem to respond to changes in the SHORTS register while it's active...
         // instead, we provide an empty buffer to prevent partial repetition of any previous buffer.
         stats[0].nodata++;
@@ -474,7 +489,14 @@ int NRF52PWM::pullRequest()
     if (streaming && !active)
     {
         active = true;
-        stats[0].irqtotalcountatstart = irqtotalcount;
+
+        stats[0].irqtotalcountatstart = irqTotalCount;
+
+        errorFlag = 0;
+        bufferCount = 0;
+        irqBeginTotalCount = irqTotalCount;
+        if (irqBeginTotalCount != irqStopTotalCount)
+            errorFlag |= NRF52PWM_ERROR_IDLEIRQ;
         upstream.dataWanted(DATASTREAM_WANTED);
 
         tryPull(bufferPlaying);
@@ -490,6 +512,8 @@ int NRF52PWM::pullRequest()
         if (bufferPlaying == 0) {
             setPwmLoopInten(streaming);
             PWM.TASKS_SEQSTART[0] = 1;
+            state = PwmState::SendingBuffers;
+
             stats[0].pwmstart_time[stats[0].pwmstarts] = DWT->CYCCNT;
             stats[0].pwmstarts++;
         } else {
@@ -509,7 +533,6 @@ void NRF52PWM::irq()
     size_t statidx = stats[0].irqcount % IRQSTATLEN;
     stats[0].irq_times[statidx] = DWT->CYCCNT;
     stats[0].irqcount++;
-    irqtotalcount++;  // this counter will eventually wrap
     if (!active) {
         stats[0].irqinactive++;
     }
@@ -520,12 +543,18 @@ void NRF52PWM::irq()
         stats[0].irqprestart++;
     }
 
+    irqTotalCount++;  // this counter will eventually wrap
+    if (state == PwmState::Inactive || state == PwmState::Priming)
+        errorFlag |= NRF52PWM_ERROR_EARLYIRQ;
+    else if (state == PwmState::Stopping || state == PwmState::Stopped)
+        errorFlag |= NRF52PWM_ERROR_LATEIRQ;
+
     // once the sequence has finished playing, load up the next buffer.
     bool end0 = PWM.EVENTS_SEQEND[0];
     if (end0)
     {
         bufferPlaying = 1;
-        tryPull(0);  // TODO log CYCCNT based duration in stats
+        tryPull(0);
         stats[0].irq0++;
 
         PWM.EVENTS_SEQEND[0] = 0;
@@ -535,10 +564,14 @@ void NRF52PWM::irq()
     if (end1)
     {
         bufferPlaying = 0;
-        tryPull(1);  // TODO log CYCCNT based duration in stats
+        tryPull(1);
         stats[0].irq1++;
 
         PWM.EVENTS_SEQEND[1] = 0;
+    }
+
+    if (end0 && end1) {
+        errorFlag |= NRF52PWM_ERROR_MULTIEVENT;
     }
 
     if (end0 && end1) {

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -1,6 +1,7 @@
 #include "NRF52PWM.h"
 #include "nrf.h"
 #include "cmsis.h"
+#include "CodalDmesg.h"
 
 using namespace codal;
 
@@ -134,14 +135,49 @@ void NRF52PWM::zeroStats() {
   * Check the statistics for anomalies and if any are found
   * DMESG print whole structure.
   */
-void NRF52PWM::anomalyCheckStats() {
-   int issues = 0;
+void NRF52PWM::anomalyCheckStats(int bufcnt) {
+    struct Nrf52PwmStats *s = &stats[0];
+    int issues = 0;
 
-   // TODO add checks
+    if (s->irqcount != bufcnt)
+        issues++;
+    if (s->irq0 + s->irq1 > s->irqcount || s->irqboth > 0)
+        issues++;
+    if (s->irqinactive > 0 || s->irqprestart > 0 || s->irqpoststop > 0)
+        issues++; 
+    if (s->pwmstarts != 1 || s->pwmstops != 1)
+        issues++;
+    if (s->preloadfails > 0 || s->dataReadyAtStop > 0 || s->nodata != 1)
+        issues++;
+    if (s->pwmstarts > 0 && s->zero_time > s->pwmstart_time[0])
+        issues++;
+    if (s->pwmstarts > 0 && s->irqcount > 0 && s->pwmstart_time[0] > s->irq_times[0])
+        issues++;
 
-   if (issues > 0) {
-      // TODO DMESG printing of everything
-   }
+    if (DWT->CYCCNT % 1000 < 10)   // TODO - REMOVE JUST FOR TESTING
+        issues++;
+
+    if (issues > 0) {
+        DMESG("NRF52PWM anomalyCheckStart(%d) issues=%d", bufcnt, issues);
+        for (int si = IRQSTATSCOUNT - 1; si >= 0; si--) {
+            struct Nrf52PwmStats *s = &stats[si];
+            DMESG("stats[%d]", si);
+            DMESG("irqcount=%d irq0=%d irq1=%d irqboth=%d",
+                s->irqcount, s->irq0, s->irq1, s->irqboth);
+            DMESG("irqinactive=%d irqprestart=%d irqpoststop=%d pwmstarts=%s pwmstops=%d",
+                s->irqinactive, s->irqprestart, s->irqpoststop, s->pwmstarts, s->pwmstops);
+            DMESG("preloadfails=%d dataReadyAtStop=%d nodata=%d",
+                s->preloadfails, s->dataReadyAtStop, s->nodata);
+            DMESG("TS %u zero", s->zero_time);
+            for (int i = 0; i < IRQSTATLEN && s->pwmstart_time[i] != 123456U; i++) {
+                DMESG("TS %u pwmstart", s->pwmstart_time[i]);
+            }
+            for (int i = 0; i < IRQSTATLEN && s->irq_times[i] != 123456U; i++) {
+                DMESG("TS %u irq %d", s->irq_times[i], s->irq_seqend[i]);
+            }
+            DMESGF("");
+        }
+    }
 }
 
 
@@ -284,6 +320,7 @@ int NRF52PWM::tryPull(uint8_t b)
         setPwmLoopInten(false);  // includes SHORTS off
         PWM.TASKS_STOP = 1;
         while(PWM.EVENTS_STOPPED == 0);
+        disable();
 
         active = false;
         bufferPlaying = 0;
@@ -361,6 +398,7 @@ int NRF52PWM::pullRequest()
 
         // Check if we've preloaded both buffers
         if (bufferPlaying == 0) {
+            enable();
             setPwmLoopInten(streaming);
             PWM.TASKS_SEQSTART[0] = 1;
             stats[0].pwmstart_time[stats[0].pwmstarts] = DWT->CYCCNT;

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -121,10 +121,12 @@ void NRF52PWM::zeroStats() {
         stats[0].irq_times[i] = 123456U;
         stats[0].pwmstart_time[i] = 123456U;
         stats[0].irq_seqend[i] = -1;
+        stats[0].trypull_dur[i] = 0;
     }
     stats[0].irqinactive = 0;
     stats[0].irqprestart = 0;
     stats[0].irqpoststop = 0;
+    stats[0].trypullcnt = 0;
     stats[0].pwmstarts = stats[0].pwmstops = 0;
     stats[0].preloadfails = 0;
     stats[0].dataReadyAtStop = 123456;
@@ -170,6 +172,15 @@ void NRF52PWM::anomalyCheckStats(int bufcnt) {
                 issues++;
         }
     }
+    // TODO - get buffer size from somewhere + clock speed for 64MHz
+    uint32_t risky_cyc = (uint32_t)(64 * 128 * periodUs * 0.90f);
+    for (int i = 0; i < IRQSTATLEN && s->trypull_dur[i] != 0; i++) {
+        
+        if (s->trypull_dur[i] >= risky_cyc) {
+            issues++;
+            break;
+        }
+    }
 
     int testtrigger = 0;
     // if (DWT->CYCCNT % 1000 < 10)   // TODO - REMOVE JUST FOR TESTING
@@ -186,17 +197,20 @@ void NRF52PWM::anomalyCheckStats(int bufcnt) {
             struct Nrf52PwmStats *s = &stats[si];
             DMESG("stats[%d]", si);
             DMESG("irqcount=%d irq0=%d irq1=%d irqboth=%d",
-                s->irqcount, s->irq0, s->irq1, s->irqboth);
+                  s->irqcount, s->irq0, s->irq1, s->irqboth);
             DMESG("irqinactive=%d irqprestart=%d irqpoststop=%d pwmstarts=%s pwmstops=%d",
-                s->irqinactive, s->irqprestart, s->irqpoststop, s->pwmstarts, s->pwmstops);
-            DMESG("preloadfails=%d dataReadyAtStop=%d nodata=%d",
-                s->preloadfails, s->dataReadyAtStop, s->nodata);
+                  s->irqinactive, s->irqprestart, s->irqpoststop, s->pwmstarts, s->pwmstops);
+            DMESG("trypullcnt=%u preloadfails=%d dataReadyAtStop=%d nodata=%d",
+                  s->trypullcnt, s->preloadfails, s->dataReadyAtStop, s->nodata);
             DMESG("TS %u zero", s->zero_time);
             for (int i = 0; i < IRQSTATLEN && s->pwmstart_time[i] != 123456U; i++) {
                 DMESG("TS %u pwmstart", s->pwmstart_time[i]);
             }
             for (int i = 0; i < IRQSTATLEN && s->irq_times[i] != 123456U; i++) {
                 DMESG("TS %u irq %d", s->irq_times[i], s->irq_seqend[i]);
+            }
+            for (int i = 0; i < IRQSTATLEN && s->trypull_dur[i] != 0; i++) {
+                DMESG("TPDUR %u", s->trypull_dur[i]);
             }
             DMESGF("");
         }
@@ -337,7 +351,9 @@ void NRF52PWM::setPwmLoopInten(bool streamingMode) {
  */
 int NRF52PWM::tryPull(uint8_t b)
 {
+    uint32_t t1_cyc = DWT->CYCCNT;
     int filled = 0;
+
     if (stopStreamingAfterBuf)
     {
         // SHORTS must be disabled before STOP as "PWM could be immediately
@@ -391,6 +407,7 @@ int NRF52PWM::tryPull(uint8_t b)
     }
   tryPullReturn:
 
+    stats[0].trypull_dur[stats[0].trypullcnt++ % IRQSTATLEN] = DWT->CYCCNT - t1_cyc;
     return filled;
 }
 

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -301,6 +301,8 @@ void NRF52PWM::setStreamingMode(bool streamingMode, bool repeatOnEmpty)
 void NRF52PWM::setPwmLoopInten(bool streamingMode) {
     if (streamingMode)
     {
+        // Clearing events here to prevent any immediate spurious interrupts
+        PWM.EVENTS_SEQEND[0] = PWM.EVENTS_SEQEND[1] = 0;
         PWM.LOOP = 1;
         PWM.SHORTS = PWM_SHORTS_LOOPSDONE_SEQSTART0_Enabled << PWM_SHORTS_LOOPSDONE_SEQSTART0_Pos; 
         PWM.INTENSET = (PWM_INTEN_SEQEND0_Enabled << PWM_INTEN_SEQEND0_Pos ) | (PWM_INTEN_SEQEND1_Enabled << PWM_INTEN_SEQEND1_Pos);

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -7,7 +7,10 @@ using namespace codal;
 
 // TODO Experimenting with larger buffer to observe behave with extra few pulses bug
 // #define  NRF52PWM_EMPTY_BUFFERSIZE  8
-#define  NRF52PWM_EMPTY_BUFFERSIZE 64
+// #define  NRF52PWM_EMPTY_BUFFERSIZE 64
+// #define  NRF52PWM_EMPTY_BUFFERSIZE  4
+#define  NRF52PWM_EMPTY_BUFFERSIZE 12
+
 static uint16_t emptyBuffer[NRF52PWM_EMPTY_BUFFERSIZE];
 
 void nrf52_pwm0_irq(void)
@@ -196,9 +199,9 @@ void NRF52PWM::anomalyCheckStats(int bufcnt) {
         for (int si = IRQSTATSCOUNT - 1; si >= 0; si--) {
             struct Nrf52PwmStats *s = &stats[si];
             DMESG("stats[%d]", si);
-            DMESG("irqcount=%d irq0=%d irq1=%d irqboth=%d",
+            DMESG("irqcount=%u irq0=%u irq1=%u irqboth=%u",
                   s->irqcount, s->irq0, s->irq1, s->irqboth);
-            DMESG("irqinactive=%d irqprestart=%d irqpoststop=%d pwmstarts=%s pwmstops=%d",
+            DMESG("irqinactive=%d irqprestart=%d irqpoststop=%d pwmstarts=%d pwmstops=%d",
                   s->irqinactive, s->irqprestart, s->irqpoststop, s->pwmstarts, s->pwmstops);
             DMESG("trypullcnt=%u preloadfails=%d dataReadyAtStop=%d nodata=%d",
                   s->trypullcnt, s->preloadfails, s->dataReadyAtStop, s->nodata);

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -328,7 +328,6 @@ int NRF52PWM::tryPull(uint8_t b)
         setPwmLoopInten(false);  // includes SHORTS off
         PWM.TASKS_STOP = 1;
         while(PWM.EVENTS_STOPPED == 0);
-        disable();
         stats[0].irqtotalcountatstop = irqtotalcount;
 
         active = false;
@@ -408,7 +407,6 @@ int NRF52PWM::pullRequest()
 
         // Check if we've preloaded both buffers
         if (bufferPlaying == 0) {
-            enable();
             setPwmLoopInten(streaming);
             PWM.TASKS_SEQSTART[0] = 1;
             stats[0].pwmstart_time[stats[0].pwmstarts] = DWT->CYCCNT;

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -157,15 +157,27 @@ void NRF52PWM::anomalyCheckStats(int bufcnt) {
         issues++;
     if (s->preloadfails > 0 || s->dataReadyAtStop > 0 || s->nodata != 1)
         issues++;
-    if (s->pwmstarts > 0 && s->zero_time > s->pwmstart_time[0])
-        issues++;
-    if (s->pwmstarts > 0 && s->irqcount > 0 && s->pwmstart_time[0] > s->irq_times[0])
-        issues++;
+    if (s->pwmstarts > 0) {
+        // The wrapping time values require care with maths and comparisons
+        uint32_t z_to_ps = s->pwmstart_time[0] - s->zero_time;
+        if ((int32_t)z_to_ps <= 0)
+            issues++;
+        if (s->irqcount > 0) {
+            uint32_t ps_to_irq = s->irq_times[0] - s->pwmstart_time[0];
+            if ((int32_t)ps_to_irq <= 0)
+                issues++;
+        }
+    }
 
     int testtrigger = 0;
     // if (DWT->CYCCNT % 1000 < 10)   // TODO - REMOVE JUST FOR TESTING
     //    testtrigger++;
 
+    // if (issues > 0) {
+    //     system_timer_wait_us(2000);  // TODO - remove, temporary to make more visible on logic analyzer
+    //     return;
+    // }
+     
     if (issues > 0 || testtrigger) {
         DMESG("NRF52PWM anomalyCheckStart(%d) issues=%d", bufcnt, issues);
         for (int si = IRQSTATSCOUNT - 1; si >= 0; si--) {
@@ -186,7 +198,6 @@ void NRF52PWM::anomalyCheckStats(int bufcnt) {
             }
             DMESGF("");
         }
-        system_timer_wait_us(600);  // TODO - remove, temporary to make more visible on logic analyzer
     }
 }
 
@@ -448,7 +459,7 @@ void NRF52PWM::irq()
     if (end0)
     {
         bufferPlaying = 1;
-        tryPull(0);
+        tryPull(0);  // TODO log CYCCNT based duration in stats
         stats[0].irq0++;
 
         PWM.EVENTS_SEQEND[0] = 0;
@@ -458,7 +469,7 @@ void NRF52PWM::irq()
     if (end1)
     {
         bufferPlaying = 0;
-        tryPull(1);
+        tryPull(1);  // TODO log CYCCNT based duration in stats
         stats[0].irq1++;
 
         PWM.EVENTS_SEQEND[1] = 0;

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -186,6 +186,7 @@ void NRF52PWM::anomalyCheckStats(int bufcnt) {
             }
             DMESGF("");
         }
+        system_timer_wait_us(600);  // TODO - remove, temporary to make more visible on logic analyzer
     }
 }
 

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -5,7 +5,9 @@
 
 using namespace codal;
 
-#define  NRF52PWM_EMPTY_BUFFERSIZE  8
+// TODO Experimenting with larger buffer to observe behave with extra few pulses bug
+// #define  NRF52PWM_EMPTY_BUFFERSIZE  8
+#define  NRF52PWM_EMPTY_BUFFERSIZE 64
 static uint16_t emptyBuffer[NRF52PWM_EMPTY_BUFFERSIZE];
 
 void nrf52_pwm0_irq(void)

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -436,10 +436,10 @@ int NRF52PWM::tryPull(uint8_t b)
         // instead, we provide an empty buffer to prevent partial repetition of any previous buffer.
         stats[0].nodata++;
         // Zero the existing played data if buffer is larger
-        size_t bufferLen = buffer[b].length() / sizeof(uint16_t);
-        if (false && bufferLen > NRF52PWM_EMPTY_BUFFERSIZE) {  // TODO REMOVE false (a temp disable)
+        size_t sampleCount = buffer[b].length() / sizeof(uint16_t);
+        if (false && sampleCount > NRF52PWM_EMPTY_BUFFERSIZE) {  // TODO REMOVE false (a temp disable)
             uint16_t *bufferData = (uint16_t *) &buffer[b][0];
-            for (size_t i = 0; i < bufferLen; i++)
+            for (size_t i = 0; i < sampleCount; i++)
                 bufferData[i] = PWM_ZERO_DC;
         } else {
             PWM.SEQ[b].PTR = (uint32_t) emptyBuffer;

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -115,13 +115,14 @@ NRF52PWM::NRF52PWM(NRF_PWM_Type *module, DataSource &source, float sampleRate, u
     upstream.connect(*this);
 }
 
+#if NRF52PWM_STATS > 0
 /**
   * Clear the statistics, typically used before starting to output PWM
   * This is flawed due to not zeroing historical data
   */
 void NRF52PWM::zeroStats() {
     // copy values to make history
-    for (int i = IRQSTATSCOUNT - 1; i >= 0; i--) {
+    for (int i = NRF52PWM_STATS - 1; i >= 0; i--) {
        memcpy(&stats[i], &stats[i - 1], sizeof(stats[0]));
     }
 
@@ -158,7 +159,7 @@ void NRF52PWM::anomalyCheckStats(int bufcnt) {
         issues++;
     if (s->irqtotalcountatstop != s->irqtotalcountatstart + s->irqcount)
         issues++;
-#if IRQSTATSCOUNT > 1 
+#if NRF52PWM_STATS > 1
     // Look for interrupts occuring while PWM should be not running
     if (s->irqtotalcountatstart != 0 && stats[1].irqtotalcountatstop != s->irqtotalcountatstart)
         issues++;
@@ -224,7 +225,7 @@ void NRF52PWM::anomalyCheckStats(int bufcnt) {
      
     if (issues > 0 || testtrigger) {
         DMESG("NRF52PWM anomalyCheckStart(%d) issues=%d", bufcnt, issues);
-        for (int si = IRQSTATSCOUNT - 1; si >= 0; si--) {
+        for (int si = NRF52PWM_STATS - 1; si >= 0; si--) {
             struct Nrf52PwmStats *s = &stats[si];
             DMESG("stats[%d]", si);
             DMESG("irqcount=%u irq0=%u irq1=%u irqboth=%u",
@@ -254,7 +255,7 @@ void NRF52PWM::anomalyCheckStats(int bufcnt) {
         }
     }
 }
-
+#endif
 
 /**
  * Determine the DAC playback sample rate to the given frequency.
@@ -389,7 +390,9 @@ void NRF52PWM::setPwmLoopInten(bool streamingMode) {
  */
 int NRF52PWM::tryPull(uint8_t b)
 {
+#if NRF52PWM_STATS > 0
     uint32_t t1_cyc = DWT->CYCCNT;
+#endif
     int filled = 0;
 
     if (stopStreamingAfterBuf)
@@ -408,20 +411,26 @@ int NRF52PWM::tryPull(uint8_t b)
         if (irqs != bufferCount)
             errorFlag |= NRF52PWM_ERROR_MISMATCHIRQ;
 
+#if NRF52PWM_STATS > 0
         stats[0].irqtotalcountatstop = irqTotalCount;
+#endif
 
         active = false;
         bufferPlaying = 0;
         stopStreamingAfterBuf = 0;
         errorFlagCumlative |= errorFlag;
 
+#if NRF52PWM_STATS > 0
         stats[0].pwmstops++;
+#endif
 
         upstream.dataWanted(DATASTREAM_NOT_WANTED);  // all the data has been PWMed
 
         // If a Pull request has been made since we decided to stop, start to fill up the
         // hardware double buffer so that we don't stall.
+#if NRF52PWM_STATS > 0
         stats[0].dataReadyAtStop = dataReady;
+#endif
         if (dataReady > 0)
         {
             dataReady--;
@@ -449,7 +458,9 @@ int NRF52PWM::tryPull(uint8_t b)
         state = PwmState::SendingLastBuffer;
         // The PWM doesn't seem to respond to changes in the SHORTS register while it's active...
         // instead, we provide an empty buffer to prevent partial repetition of any previous buffer.
+#if NRF52PWM_STATS > 0
         stats[0].nodata++;
+#endif
         // Zero the existing played data if buffer is larger
         size_t sampleCount = buffer[b].length() / sizeof(uint16_t);
         if (false && sampleCount > NRF52PWM_EMPTY_BUFFERSIZE) {  // TODO REMOVE false (a temp disable)
@@ -464,7 +475,9 @@ int NRF52PWM::tryPull(uint8_t b)
     }
   tryPullReturn:
 
+#if NRF52PWM_STATS > 0
     stats[0].trypull_dur[stats[0].trypullcnt++ % IRQSTATLEN] = DWT->CYCCNT - t1_cyc;
+#endif
     return filled;
 }
 
@@ -489,9 +502,9 @@ int NRF52PWM::pullRequest()
     if (streaming && !active)
     {
         active = true;
-
+#if NRF52PWM_STATS > 0
         stats[0].irqtotalcountatstart = irqTotalCount;
-
+#endif
         errorFlag = 0;
         bufferCount = 0;
         irqBeginTotalCount = irqTotalCount;
@@ -514,11 +527,15 @@ int NRF52PWM::pullRequest()
             PWM.TASKS_SEQSTART[0] = 1;
             state = PwmState::SendingBuffers;
 
+#if NRF52PWM_STATS > 0
             stats[0].pwmstart_time[stats[0].pwmstarts] = DWT->CYCCNT;
             stats[0].pwmstarts++;
+#endif
         } else {
             active = false;
+#if NRF52PWM_STATS > 0
             stats[0].preloadfails++;
+#endif
         }
     }
 
@@ -530,6 +547,7 @@ int NRF52PWM::pullRequest()
  */
 void NRF52PWM::irq()
 {
+#if NRF52PWM_STATS > 0
     size_t statidx = stats[0].irqcount % IRQSTATLEN;
     stats[0].irq_times[statidx] = DWT->CYCCNT;
     stats[0].irqcount++;
@@ -542,6 +560,7 @@ void NRF52PWM::irq()
     if (stats[0].pwmstarts == 0) {
         stats[0].irqprestart++;
     }
+#endif
 
     irqTotalCount++;  // this counter will eventually wrap
     if (state == PwmState::Inactive || state == PwmState::Priming)
@@ -555,8 +574,9 @@ void NRF52PWM::irq()
     {
         bufferPlaying = 1;
         tryPull(0);
+#if NRF52PWM_STATS > 0
         stats[0].irq0++;
-
+#endif
         PWM.EVENTS_SEQEND[0] = 0;
     }
 
@@ -565,19 +585,21 @@ void NRF52PWM::irq()
     {
         bufferPlaying = 0;
         tryPull(1);
+#if NRF52PWM_STATS > 0
         stats[0].irq1++;
-
+#endif
         PWM.EVENTS_SEQEND[1] = 0;
     }
 
     if (end0 && end1) {
         errorFlag |= NRF52PWM_ERROR_MULTIEVENT;
     }
-
+#if NRF52PWM_STATS > 0
     if (end0 && end1) {
         stats[0].irqboth++;
     }
     stats[0].irq_seqend[statidx] = (end1 ? 0b10 : 0) + (end0 ? 0b01 : 0);
+#endif
 }
 
 /**

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -231,6 +231,7 @@ int NRF52PWM::tryPull(uint8_t b)
         active = false;
         bufferPlaying = 0;
         stopStreamingAfterBuf = 0;
+        upstream.dataWanted(DATASTREAM_NOT_WANTED);  // all the data has been sent
 
         // If a Pull request has been made since we decided to stop, start to fill up the
         // hardware double buffer so that we don't stall.

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -5,13 +5,8 @@
 
 using namespace codal;
 
-// TODO Experimenting with larger buffer to observe behave with extra few pulses bug
-// #define  NRF52PWM_EMPTY_BUFFERSIZE  8
-// #define  NRF52PWM_EMPTY_BUFFERSIZE 64
-// #define  NRF52PWM_EMPTY_BUFFERSIZE  4
-#define  NRF52PWM_EMPTY_BUFFERSIZE 12
+#define NRF52PWM_EMPTY_BUFFERSIZE 40
 #define PWM_ZERO_DC 0x8000  // low output
-
 static uint16_t emptyBuffer[NRF52PWM_EMPTY_BUFFERSIZE];
 
 void nrf52_pwm0_irq(void)
@@ -460,7 +455,7 @@ int NRF52PWM::tryPull(uint8_t b)
 #endif
         // Zero the existing played data if buffer is larger
         size_t sampleCount = buffer[b].length() / sizeof(uint16_t);
-        if (false && sampleCount > NRF52PWM_EMPTY_BUFFERSIZE) {  // TODO REMOVE false (a temp disable)
+        if (sampleCount > NRF52PWM_EMPTY_BUFFERSIZE) {
             uint16_t *bufferData = (uint16_t *) &buffer[b][0];
             for (size_t i = 0; i < sampleCount; i++)
                 bufferData[i] = PWM_ZERO_DC;

--- a/source/NRF52PWM.cpp
+++ b/source/NRF52PWM.cpp
@@ -342,7 +342,7 @@ int NRF52PWM::setDecoderMode(uint32_t mode)
 /**
  * Defines if the PWM module should maintain playout ordering of buffers, or always play the most recent buffer provided.
  * 
- * @ param streamingMode If true, buffers will be streamed in order they are received. If false, the most recent buffer supplied always takes prescedence.
+ * @ param streamingMode If true, buffers will be streamed in order they are received. If false, the most recent buffer supplied always takes precedence.
  * @ param repeatOnEmpty If set to true, the last buffer received will be repeated when no data is available. If false, the PWM channel will be suspended.
  */
 void NRF52PWM::setStreamingMode(bool streamingMode, bool repeatOnEmpty)
@@ -355,7 +355,7 @@ void NRF52PWM::setStreamingMode(bool streamingMode, bool repeatOnEmpty)
 /**
  * Sets PWM hardware registers for chained buffers or simple one shot playback
  * 
- * @ param streamingMode If true, buffers will be streamed in order they are received. If false, the most recent buffer supplied always takes prescedence.
+ * @ param streamingMode If true, buffers will be streamed in order they are received. If false, the most recent buffer supplied always takes precedence.
  */
 void NRF52PWM::setPwmLoopInten(bool streamingMode) {
     if (streamingMode)

--- a/source/NRF52TouchSensor.cpp
+++ b/source/NRF52TouchSensor.cpp
@@ -33,8 +33,8 @@ static NRF52TouchSensor *instance = NULL;
 static void touch_sense_irq(uint16_t mask)
 {
     if (instance) {
-        Event evt;
-        instance->onSampleEvent(evt);
+        Event unused_evt(0, 0, 0, CREATE_ONLY);  // more lightweight than default constructor
+        instance->onSampleEvent(unused_evt);
     }
 }
 

--- a/source/WS2812B.cpp
+++ b/source/WS2812B.cpp
@@ -94,7 +94,7 @@ ManagedBuffer WS2812B::pull()
     while (out < end)
     {
         // Add the front/rear padding if aplicable
-        if (samplesSent < WS2812B_ZERO_PADDING || samplesSent > (WS2812B_ZERO_PADDING + samplesToSend))
+        if (samplesSent < WS2812B_ZERO_PADDING || samplesSent >= (WS2812B_ZERO_PADDING + samplesToSend))
         {
             *out = WS2812B_PAD;
         }

--- a/source/WS2812B.cpp
+++ b/source/WS2812B.cpp
@@ -132,7 +132,7 @@ void WS2812B::pull(ManagedBuffer &buffer)
 
 
 /**
- * Experimental: used by downstream caller to indicate all data has been sent.
+ * Downstream caller uses this to indicate all data has been sent.
  * @param wanted set to DATASTREAM_NOT_WANTED to indicate all data sent
  */
 void WS2812B::dataWanted(int wanted)

--- a/source/WS2812B.cpp
+++ b/source/WS2812B.cpp
@@ -79,14 +79,20 @@ WS2812B::setBufferSize(int size)
 }
 
 /**
- * Provide the next available ManagedBuffer to our downstream caller, if available.
+ * Provide the next lump of data to our downstream caller using an existing ManagerBuffer.
  */
-ManagedBuffer WS2812B::pull()
+void WS2812B::pull(ManagedBuffer &buffer)
 {
     // Calculate the amount of data we can transfer in this pull request.
-    // Ensure we send at least two buffers, as most downstream components will likely be double buffered...
+    // Pixels plus RESET period before and after pixel data
     int totalSamples = max(outputBufferSize, samplesToSend + 2 * WS2812B_ZERO_PADDING);
-    ManagedBuffer buffer(outputBufferSize);
+    
+    // Adjust buffer length if required
+    int curBufLen = buffer.length();
+    if (curBufLen < outputBufferSize)
+        buffer = ManagedBuffer(outputBufferSize, BufferInitialize::None);
+    else if (curBufLen > outputBufferSize)
+        buffer.truncate(outputBufferSize);
 
     uint16_t *out = (uint16_t *) &buffer[0];
     uint16_t *end = (uint16_t *) &buffer[buffer.length()];
@@ -113,13 +119,6 @@ ManagedBuffer WS2812B::pull()
     // If we still have data to send, indicate this to our downstream component
     if (samplesSent < totalSamples)
         downstream->pullRequest();
-    
-    // Replaced by experimental borrowing of dataWanted member function
-    // If we have completed playback and blockingbehaviour was requested, wake the fiber that is blocked waiting.
-    // if ((samplesSent >= totalSamples) && blockingPlayout)
-    //    lock.notify();
-
-    return buffer;
 }
 
 

--- a/source/WS2812B.cpp
+++ b/source/WS2812B.cpp
@@ -83,7 +83,7 @@ WS2812B::setBufferSize(int size)
 void WS2812B::pull(ManagedBuffer &buffer)
 {
     // Calculate the amount of data we can transfer in this pull request.
-    // Pixels plus RESET period before and after pixel data
+    // Pixels plus RESET periods before and after pixel data
     int totalSamples = max(outputBufferSize, samplesToSend + 2 * WS2812B_ZERO_PADDING);
     
     // Adjust buffer length if required
@@ -96,6 +96,8 @@ void WS2812B::pull(ManagedBuffer &buffer)
     uint16_t *out = (uint16_t *) &buffer[0];
     uint16_t *end = (uint16_t *) &buffer[buffer.length()];
 
+    int index = -1;
+    int bit = 0, bitmask =0;
     while (out < end)
     {
         // Add the front/rear padding if aplicable
@@ -105,10 +107,18 @@ void WS2812B::pull(ManagedBuffer &buffer)
         }
         else
         {
-            int index = (samplesSent - WS2812B_ZERO_PADDING) / 8;
-            int bit = (samplesSent - WS2812B_ZERO_PADDING) % 8;
+            if (index < 0) {
+                index = (samplesSent - WS2812B_ZERO_PADDING) / 8;
+                bit = 7 - (samplesSent - WS2812B_ZERO_PADDING) % 8;
+                bitmask = 0x01 << bit;
+            }
 
-            *out = ((data[index] >> (7-bit)) & 1) ? WS2812B_HIGH : WS2812B_LOW;
+            *out = (data[index] & bitmask) ? WS2812B_HIGH : WS2812B_LOW;
+            bitmask >>= 1;
+            if (bitmask == 0) {
+                index++;
+                bitmask = 0x01 << 7;
+            }
         }
 
         out++;

--- a/source/WS2812B.cpp
+++ b/source/WS2812B.cpp
@@ -114,12 +114,26 @@ ManagedBuffer WS2812B::pull()
     if (samplesSent < totalSamples)
         downstream->pullRequest();
     
+    // Replaced by experimental borrowing of dataWanted member function
     // If we have completed playback and blockingbehaviour was requested, wake the fiber that is blocked waiting.
-    if ((samplesSent >= totalSamples) && blockingPlayout)
-        lock.notify();
+    // if ((samplesSent >= totalSamples) && blockingPlayout)
+    //    lock.notify();
 
     return buffer;
 }
+
+
+/**
+ * Experimental: used by downstream caller to indicate all data has been sent.
+ * @param wanted set to DATASTREAM_NOT_WANTED to indicate all data sent
+ */
+void WS2812B::dataWanted(int wanted)
+{
+    if (wanted == DATASTREAM_NOT_WANTED && blockingPlayout)
+        lock.notify();
+}
+
+
 
 /**
  * Perform a non-blocking playout of the given 24 bit RGB/GRB encoded datastream. Thhis method performs no

--- a/source/WS2812B.cpp
+++ b/source/WS2812B.cpp
@@ -32,11 +32,10 @@ using namespace codal;
  * @param pwm The PWM peripheral to use to generate the output
  * @param pin The pin connected to the WS2812B pixel strip
  */
-WS2812B::WS2812B()
+WS2812B::WS2812B() : lock(0)
 {
     this->downstream = NULL;
     this->setBufferSize(WS2812B_BUFFER_SIZE);
-    lock.wait();
 } 
 
 /*

--- a/source/WS2812B.cpp
+++ b/source/WS2812B.cpp
@@ -197,6 +197,18 @@ void WS2812B::_play(const void *data, int length, bool mode)
 
     downstream->pullRequest();
 
+    // TODO - remove these 2ms experimental pauses
+#if 0
+    fiber_sleep(2);
+#endif
+#if 0
+    system_timer_wait_us(2000);
+#endif
+#if 0
+    uint32_t now_cyc = DWT->CYCCNT;
+    while ((uint32_t)(DWT->CYCCNT - now_cyc) < (uint32_t)(2 * 64 * 1000)) {};
+#endif
+
     if (this->blockingPlayout)
         lock.wait();
 }

--- a/source/WS2812B.cpp
+++ b/source/WS2812B.cpp
@@ -137,10 +137,10 @@ void WS2812B::pull(ManagedBuffer &buffer)
  */
 void WS2812B::dataWanted(int wanted)
 {
+    DataSource::dataWanted(wanted);
     if (wanted == DATASTREAM_NOT_WANTED && blockingPlayout)
         lock.notify();
 }
-
 
 
 /**

--- a/source/WS2812B.cpp
+++ b/source/WS2812B.cpp
@@ -197,18 +197,6 @@ void WS2812B::_play(const void *data, int length, bool mode)
 
     downstream->pullRequest();
 
-    // TODO - remove these 2ms experimental pauses
-#if 0
-    fiber_sleep(2);
-#endif
-#if 0
-    system_timer_wait_us(2000);
-#endif
-#if 0
-    uint32_t now_cyc = DWT->CYCCNT;
-    while ((uint32_t)(DWT->CYCCNT - now_cyc) < (uint32_t)(2 * 64 * 1000)) {};
-#endif
-
     if (this->blockingPlayout)
         lock.wait();
 }

--- a/source/neopixel.cpp
+++ b/source/neopixel.cpp
@@ -8,11 +8,6 @@ using namespace codal;
 
 #if CONFIG_ENABLED(HARDWARE_NEOPIXEL)
 
-int breakpoint1() {
-    int a=1;
-    return a * 123;
-}
-
 void codal::neopixel_send_buffer(Pin &pin, const uint8_t *ptr, int numBytes)
 {
     static NRF52PWM *pwm = NULL;
@@ -20,12 +15,13 @@ void codal::neopixel_send_buffer(Pin &pin, const uint8_t *ptr, int numBytes)
 
     if (pwm == NULL)
     {
-        // TODO remove this - for CYCCNT for stats
+#if NRF52PWM_STATS > 0
         // Enable Data Watchpoint and Trace Unit (DWT) Cycle Counter
+        // This is needed if not running under a debugger
         CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
         DWT->CYCCNT = 0;
         DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
-
+#endif
         ws = new WS2812B();
         pwm = new NRF52PWM(NRF_PWM2, *ws, WS2812B_PWM_FREQ);
         pwm->setStreamingMode(true, false);
@@ -34,37 +30,17 @@ void codal::neopixel_send_buffer(Pin &pin, const uint8_t *ptr, int numBytes)
 
     pwm->connectPin(pin, 0);
 
-    // TODO - remove debugging code
-    if (0) {
-        uint32_t prev_count  = pwm->stats[0].irqcount;
-        system_timer_wait_us(400);
-        if (pwm->stats[0].irqcount != prev_count) {
-            target_panic(701); 
-        }
-    }
-
+#if NRF52PWM_STATS > 0
     pwm->zeroStats();
+#endif
     ws->play(ptr, numBytes);
+#if NRF52PWM_STATS > 0
     int samplesPerBuffer = WS2812B_BUFFER_SIZE / 2;
     int samples = (numBytes * 8 + 2 * WS2812B_ZERO_PADDING);
     int bufcnt = max(2,
                      samples / samplesPerBuffer + (samples % samplesPerBuffer > 0 ? 1 : 0));
     pwm->anomalyCheckStats(bufcnt);
-
-    // TODO - remove debuggin code
-    volatile int discard;
-    if (pwm->stats[0].irqprestart > 0 || pwm->stats[0].irqpoststop > 0) {
-        discard = breakpoint1();
-    }
-
-    // TODO - remove debugging code
-    if (0) {
-        uint32_t prev_count  = pwm->stats[0].irqcount;
-        system_timer_wait_us(400);
-        if (pwm->stats[0].irqcount != prev_count) {
-            target_panic(702); 
-        }
-    }
+#endif
 }
 
 #else

--- a/source/neopixel.cpp
+++ b/source/neopixel.cpp
@@ -47,7 +47,7 @@ void codal::neopixel_send_buffer(Pin &pin, const uint8_t *ptr, int numBytes)
     ws->play(ptr, numBytes);
     int samplesPerBuffer = WS2812B_BUFFER_SIZE / 2;
     int samples = (numBytes * 8 + 2 * WS2812B_ZERO_PADDING);
-    int bufcnt = min(2,
+    int bufcnt = max(2,
                      samples / samplesPerBuffer + (samples % samplesPerBuffer > 0 ? 1 : 0));
     pwm->anomalyCheckStats(bufcnt);
 

--- a/source/neopixel.cpp
+++ b/source/neopixel.cpp
@@ -47,7 +47,8 @@ void codal::neopixel_send_buffer(Pin &pin, const uint8_t *ptr, int numBytes)
     ws->play(ptr, numBytes);
     int samplesPerBuffer = WS2812B_BUFFER_SIZE / 2;
     int samples = (numBytes * 8 + 2 * WS2812B_ZERO_PADDING);
-    int bufcnt = samples / samplesPerBuffer + (samples % samplesPerBuffer > 0 ? 1 : 0);
+    int bufcnt = min(2,
+                     samples / samplesPerBuffer + (samples % samplesPerBuffer > 0 ? 1 : 0));
     pwm->anomalyCheckStats(bufcnt);
 
     // TODO - remove debuggin code

--- a/source/neopixel.cpp
+++ b/source/neopixel.cpp
@@ -19,7 +19,6 @@ void codal::neopixel_send_buffer(Pin &pin, const uint8_t *ptr, int numBytes)
         pwm = new NRF52PWM(NRF_PWM2, *ws, WS2812B_PWM_FREQ);
         pwm->setStreamingMode(true, false);
         pwm->setDecoderMode(PWM_DECODER_LOAD_Common);
-        pwm->setSampleRate(WS2812B_PWM_FREQ);
     }
 
     pwm->connectPin(pin, 0);

--- a/source/neopixel.cpp
+++ b/source/neopixel.cpp
@@ -25,8 +25,8 @@ void codal::neopixel_send_buffer(Pin &pin, const uint8_t *ptr, int numBytes)
     pwm->connectPin(pin, 0);
 
     pwm->zeroStats();
-
     ws->play(ptr, numBytes);
+    pwm->anomalyCheckStats();
 }
 
 #else

--- a/source/neopixel.cpp
+++ b/source/neopixel.cpp
@@ -8,6 +8,11 @@ using namespace codal;
 
 #if CONFIG_ENABLED(HARDWARE_NEOPIXEL)
 
+int breakpoint1() {
+    int a=1;
+    return a * 123;
+}
+
 void codal::neopixel_send_buffer(Pin &pin, const uint8_t *ptr, int numBytes)
 {
     static NRF52PWM *pwm = NULL;
@@ -23,9 +28,36 @@ void codal::neopixel_send_buffer(Pin &pin, const uint8_t *ptr, int numBytes)
 
     pwm->connectPin(pin, 0);
 
+    // TODO - remove debugging code
+    if (0) {
+        int prev_count  = pwm->stats[0].irqcount;
+        system_timer_wait_us(400);
+        if (pwm->stats[0].irqcount != prev_count) {
+            target_panic(701); 
+        }
+    }
+
     pwm->zeroStats();
     ws->play(ptr, numBytes);
-    pwm->anomalyCheckStats();
+    int samplesPerBuffer = WS2812B_BUFFER_SIZE / 2;
+    int samples = (numBytes * 8 + 2 * WS2812B_ZERO_PADDING);
+    int bufcnt = samples / samplesPerBuffer + (samples % samplesPerBuffer > 0 ? 1 : 0);
+    pwm->anomalyCheckStats(bufcnt);
+
+    // TODO - remove debuggin code
+    volatile int discard;
+    if (pwm->stats[0].irqprestart > 0 || pwm->stats[0].irqpoststop > 0) {
+        discard = breakpoint1();
+    }
+
+    // TODO - remove debugging code
+    if (0) {
+        int prev_count  = pwm->stats[0].irqcount;
+        system_timer_wait_us(400);
+        if (pwm->stats[0].irqcount != prev_count) {
+            target_panic(702); 
+        }
+    }
 }
 
 #else

--- a/source/neopixel.cpp
+++ b/source/neopixel.cpp
@@ -24,6 +24,8 @@ void codal::neopixel_send_buffer(Pin &pin, const uint8_t *ptr, int numBytes)
 
     pwm->connectPin(pin, 0);
 
+    pwm->zeroStats();
+
     ws->play(ptr, numBytes);
 }
 

--- a/source/neopixel.cpp
+++ b/source/neopixel.cpp
@@ -20,6 +20,12 @@ void codal::neopixel_send_buffer(Pin &pin, const uint8_t *ptr, int numBytes)
 
     if (pwm == NULL)
     {
+        // TODO remove this - for CYCCNT for stats
+        // Enable Data Watchpoint and Trace Unit (DWT) Cycle Counter
+        CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+        DWT->CYCCNT = 0;
+        DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
+
         ws = new WS2812B();
         pwm = new NRF52PWM(NRF_PWM2, *ws, WS2812B_PWM_FREQ);
         pwm->setStreamingMode(true, false);

--- a/source/neopixel.cpp
+++ b/source/neopixel.cpp
@@ -30,7 +30,7 @@ void codal::neopixel_send_buffer(Pin &pin, const uint8_t *ptr, int numBytes)
 
     // TODO - remove debugging code
     if (0) {
-        int prev_count  = pwm->stats[0].irqcount;
+        uint32_t prev_count  = pwm->stats[0].irqcount;
         system_timer_wait_us(400);
         if (pwm->stats[0].irqcount != prev_count) {
             target_panic(701); 
@@ -52,7 +52,7 @@ void codal::neopixel_send_buffer(Pin &pin, const uint8_t *ptr, int numBytes)
 
     // TODO - remove debugging code
     if (0) {
-        int prev_count  = pwm->stats[0].irqcount;
+        uint32_t prev_count  = pwm->stats[0].irqcount;
         system_timer_wait_us(400);
         if (pwm->stats[0].irqcount != prev_count) {
             target_panic(702); 


### PR DESCRIPTION
#### Issue Tickets

This is one of a trio of PRs which fixes issues with `neopixel_send_buffer()` used by MicroPython's:

 - https://github.com/microbit-foundation/micropython-microbit-v2/issues/227 & https://github.com/lancaster-university/codal-microbit-v2/issues/475 - glitches on WS2812B RGB LEDs (includes Adafruit's NeoPixels)
 - https://github.com/microbit-foundation/micropython-microbit-v2/issues/228 - after 8 days of no low-level errors in testing I believe these were all caused by these bugs
 - https://github.com/lancaster-university/codal-microbit-v2/issues/241
 - https://github.com/lancaster-university/codal-nrf52/issues/58 - spotted whilst using debugger
 - https://github.com/lancaster-university/codal-nrf52/issues/59 - concise summary ticket of bug fixes, enhancements and hygiene issues.
 - https://github.com/lancaster-university/codal-nrf52/issues/60 - noted while searching for inefficiencies in priority 3 interrupt handlers

@finneyj @martinwork @microbit-carlos may be interested in this.

#### Summary

The summary of changes for all three PRs (this one has the bulk of them in `WS2812B` and `NRF52PWM` classes) is:
 - added `volatile` to variables in classes for better safety between main and interrupt handler code
 - made `WS2812B::play()` fully blocking to prevent hazardous overlapping executions of `neopixel_send_buffer()` - this was **_implemented using the existing_** `dataWanted() ` perhaps not quite how it's intended to be used?
 - fixed the one extra pulse bug
 - fixied PWM stopping using same technique as `nrfx_pwm_stop()` + sprinkling of event clears of `EVENTS_SEQEND`
 - dramatically reduced chance of bogus pulses occuring after end of transmission by zeroing data buffer and using slightly enlarged `emptyBuffer`
 - added an `errorFlag` and `errorFlagCumulative` (not yet exposed via API or MicroPython)
 - `#if` disabled currently: added detail pwm statistics and error counters with history and anomalying DMESG printing (only intended for future debugging - this could be removed)
 - safer conditionals with `dataReady`
 - made interrupt handler in `NRF52TouchSensor` more efficient.
 - more efficient transfer of from `WS2812B` to `NRF52PWM` by reusing existing buffers, removing data initialisation for `ManagedBuffer` and optimised code - **_this required a minor addition to the interface_** for `DataSource`
 - after some testing and consideration **_increased the priority of NRF52PWM interrupts by changing_** `PWM2_IRQn` from 3 to 2.
 - trivial changes: fixes for `periodUs`, remove of redundant `setSampleRate()`, change lock initalisation in `WS28128B` - these had no impact on glitching bugs.

I've highlighted the three things in bold italics which I think need the most reviewing.

The fixes were applied to a branch from master made on the 24th July 2025. This will clearly be different code to the production release where these bugs were originally observed:`MicroPython v1.18 on 2023-10-30; micro:bit v2.1.2 with nRF52833` on a V2.2.1 micro;bit.

The diff looks a lot bigger than it really is, the bulk of the lines are the PWM statistics code which is `#if`ed out.

---

### Testing

The bug fixes have been tested:

1. As they were developed in debugger and with logic analyzer, documented in comments in https://github.com/lancaster-university/codal-microbit-v2/issues/475
2. [Recently for four days on three micro:bits](https://github.com/lancaster-university/codal-nrf52/issues/59#issuecomment-3165992447) with occasional visual observation running [neopixel-thirty-bug-colourcycle-26.py](https://github.com/kevinjwalters/micropython-examples/blob/master/microbit/neopixel-thirty-bug-colourcycle-26.py)
3. [Four days on four micro:bits](https://github.com/lancaster-university/codal-nrf52/issues/59#issuecomment-3176992453) with occasional visual observation running [neopixel-thirty-bug-timedetector-16.py](https://github.com/kevinjwalters/micropython-examples/blob/master/microbit/neopixel-thirty-bug-timedetector-16.py) & [neopixel-thirty-bug-timedetector-23.py](https://github.com/kevinjwalters/micropython-examples/blob/master/microbit/neopixel-thirty-bug-timedetector-23.py) & [neopixel-thirty-bug-colourcycle-26.py](https://github.com/kevinjwalters/micropython-examples/blob/master/microbit/neopixel-thirty-bug-colourcycle-26.py) & [zhhclock](https://github.com/kevinjwalters/micropython-examples/blob/master/zhhclock/zhhclock.py) - [video](https://www.youtube.com/watch?v=uYppB6u0VUg)

---

Partner PRs:
 - https://github.com/lancaster-university/codal-core/pull/184
 - https://github.com/lancaster-university/codal-microbit-v2/pull/505

---

Additional information (_not_ required reading):
 - [Debugging Rare RGB LED Glitches in MicroPython on BBC micro:bit](https://medium.com/@kevinjwalters/debugging-rare-rgb-led-glitches-in-micropython-on-bbc-micro-bit-ed2ab468d192)
 - [Everything You Always Wanted to Know About Debugging the Nordic nRF52 PWM Peripheral and Cortex ARM Interrupts* (*But were afraid to ask)](https://kevinjwalters.medium.com/everything-you-always-wanted-to-know-about-debugging-the-nordic-nrf52-pwm-peripheral-and-cortex-arm-9be8fbf327e5)
